### PR TITLE
修复：技能、BUFF

### DIFF
--- a/src/Application.Core/Channel/Net/Handlers/AbstractDealDamageHandler.cs
+++ b/src/Application.Core/Channel/Net/Handlers/AbstractDealDamageHandler.cs
@@ -212,7 +212,13 @@ public abstract class AbstractDealDamageHandler : ChannelHandlerBase
                     int totDamageToOneMonster = 0;
                     var onedList = (target.Value?.damageLines ?? []).ToArray();
 
-                    if (attack.magic ? monster.isBuffed(MonsterStatus.MAGIC_IMMUNITY) : monster.isBuffed(MonsterStatus.WEAPON_IMMUNITY))
+                    // 已经在客户端计算过了，这里只能用是否拥有buff简单的判断（假如效果很低，但是客户端开挂改成100%，服务端也没办法区分）
+                    if (attack.magic && monster.isBuffed(MonsterStatus.MAGIC_IMMUNITY) && !player.HasBuff(BuffStat.RESPECT_MIMMUNE))
+                    {
+                        Array.Fill(onedList, 1);
+                    }
+
+                    if (!attack.magic && monster.isBuffed(MonsterStatus.WEAPON_IMMUNITY) && !player.HasBuff(BuffStat.RESPECT_PIMMUNE))
                     {
                         Array.Fill(onedList, 1);
                     }

--- a/src/Application.Core/Channel/Services/DataService.cs
+++ b/src/Application.Core/Channel/Services/DataService.cs
@@ -215,7 +215,7 @@ namespace Application.Core.Channel.Services
                 int skillid = item.SkillId;
                 long length = item.Length;
                 long startTime = item.StartTime;
-                if (skillid != 5221999 && (length + startTime < c.CurrentServer.Node.getCurrentTime()))
+                if (skillid != Corsair.BATTLE_SHIP_HP && (length + startTime < c.CurrentServer.Node.getCurrentTime()))
                 {
                     continue;
                 }

--- a/src/Application.Core/Game/Players/Character.cs
+++ b/src/Application.Core/Game/Players/Character.cs
@@ -1086,7 +1086,7 @@ public partial class Player
 
     public void announceBattleshipHp()
     {
-        sendPacket(PacketCreator.skillCooldown(5221999, battleshipHp));
+        sendPacket(PacketCreator.skillCooldown(Corsair.BATTLE_SHIP_HP, battleshipHp));
     }
 
     public void decreaseBattleshipHp(int decrease)
@@ -1096,15 +1096,17 @@ public partial class Player
         {
             Skill battleship = SkillFactory.GetSkillTrust(Corsair.BATTLE_SHIP);
             int cooldown = battleship.getEffect(getSkillLevel(battleship)).getCooldown();
+
             sendPacket(PacketCreator.skillCooldown(Corsair.BATTLE_SHIP, cooldown));
             addCooldown(Corsair.BATTLE_SHIP, Client.CurrentServer.Node.getCurrentTime(), cooldown * 1000);
-            removeCooldown(5221999);
+
+            removeCooldown(Corsair.BATTLE_SHIP_HP);
             cancelEffectFromBuffStat(BuffStat.MONSTER_RIDING);
         }
         else
         {
             announceBattleshipHp();
-            addCooldown(5221999, 0, long.MaxValue);
+            addCooldown(Corsair.BATTLE_SHIP_HP, 0, battleshipHp);
         }
     }
 
@@ -3050,13 +3052,16 @@ public partial class Player
         }
     }
 
-    public void setBattleshipHp(int battleshipHp)
-    {
-        this.battleshipHp = battleshipHp;
-    }
-
     public void resetBattleshipHp()
     {
+        // a1: skillid, a2: skillLevel, a3: level
+        //  int __cdecl sub_7665F1(int a1, int a2, int a3)
+        //  {
+        //    if ( a1 == 5221006 )
+        //      return 200 * (a3 + 2 * a2 - 120);
+        //    else
+        //      return -1;
+        //  }
         int bshipLevel = Math.Max(getLevel() - 120, 0);  // thanks alex12 for noticing battleship HP issues for low-level players
         this.battleshipHp = 400 * getSkillLevel(SkillFactory.GetSkillTrust(Corsair.BATTLE_SHIP)) + (bshipLevel * 200);
     }

--- a/src/Application.Core/Game/Players/Skill.cs
+++ b/src/Application.Core/Game/Players/Skill.cs
@@ -174,6 +174,11 @@ namespace Application.Core.Game.Players
             long curTime = Client.CurrentServer.Node.getCurrentTime();
             foreach (var bel in es)
             {
+                if (bel.Key == Corsair.BATTLE_SHIP_HP)
+                {
+                    continue;
+                }
+
                 CooldownValueHolder mcdvh = bel.Value;
                 if (curTime >= mcdvh.startTime + mcdvh.length)
                 {
@@ -209,7 +214,7 @@ namespace Application.Core.Game.Players
         }
         public void giveCoolDowns(int skillid, long starttime, long length)
         {
-            if (skillid == 5221999)
+            if (skillid == Corsair.BATTLE_SHIP_HP)
             {
                 this.battleshipHp = (int)length;
                 addCooldown(skillid, 0, length);

--- a/src/Application.Core/server/StatEffect.cs
+++ b/src/Application.Core/server/StatEffect.cs
@@ -28,7 +28,7 @@ using Application.Core.Game.Maps;
 using Application.Core.Game.Maps.AnimatedObjects;
 using Application.Core.Game.Maps.Mists;
 using Application.Core.Game.Skills;
-using Application.Shared.Constants.Map;
+using Application.Core.tools.RandomUtils;
 using Application.Templates.Item.Cash;
 using Application.Templates.Item.Consume;
 using Application.Templates.Skill;
@@ -53,19 +53,17 @@ public class StatEffect
     private short watk, matk, wdef, mdef, acc, avoid, speed, jump;
     private short hp, mp;
     private double hpR, mpR;
-    private short mhpRRate, mmpRRate, mobSkill, mobSkillLevel;
+    private short mhpRRate, mmpRRate;
     private sbyte mhpR, mmpR;
     private short mpCon, hpCon;
-    private int duration = -1, target, barrier;
+    private int duration = -1;
     private bool overTime;
     private int sourceid;
-    private int moveTo = -1;
-    private int cp, nuffSkill;
     private List<Disease> cureDebuffs;
     private bool skill;
     private List<BuffStatValue> statups;
     private Dictionary<MonsterStatus, int> monsterStatus;
-    private int x, y, mobCount = 1, moneyCon, cooldown, morphId = 0, ghost, fatigue, berserk, booster;
+    private int x, y, mobCount = 1, moneyCon, cooldown, morphId = 0;
     private int prop = 100;
     private int itemCon, itemConNo;
     private int damage = 100, attackCount = 1, fixdamage = -1;
@@ -85,8 +83,6 @@ public class StatEffect
 
 
     public List<ScopedEffect> ScopedEffects { get; } = [];
-    int _itemCode = -1;
-    int _itemRange = -1;
     public int Prob { get; private set; }
     public string? DefenseAtt { get; private set; }
     public string? DefenseState { get; private set; }
@@ -99,22 +95,32 @@ public class StatEffect
 
     public int getCardRate(Player chr, int itemid)
     {
-        if (!isActive(chr))
+        //if (!isActive(chr))
+        //{
+        //    return 0;
+        //}
+        if (itemid == 0 && EffectTemplate is IItemStatEffectMesoUp mesoUp)
         {
-            return 0;
+            return mesoUp.Prob;
         }
-        if (_itemCode == -1 && _itemRange == -1)
+        if (itemid > 0 && EffectTemplate is IItemStatEffectItemUp itemUp)
         {
-            return Prob;
+            if (itemUp.ItemUp == 1)
+            {
+                return itemUp.Prob;
+            }
+
+            else if (itemUp.ItemUp == 2 && itemid == itemUp.ItemCode)
+            {
+                return itemUp.Prob;
+            }
+
+            else if (itemUp.ItemUp == 3 && itemid / 10000 == itemUp.ItemRange)
+            {
+                return itemUp.Prob;
+            }
         }
-        if (itemid == _itemCode)
-        {
-            return Prob;
-        }
-        if (itemid / 10000 == _itemRange)
-        {
-            return Prob;
-        }
+
         return 0;
     }
 
@@ -240,31 +246,13 @@ public class StatEffect
 
         if (template is IStatEffectExpInc expInc && expInc.ExpInc > 0)
         {
+            // 不像buff  更像一次性获得经验
             addBuffStatPairToListIfNotZero(statups, BuffStat.EXP_INCREASE, expInc.ExpInc);
-        }
-
-        if (template is IItemStatEffectMC mcItem)
-        {
-            cp = mcItem.CP;
-            nuffSkill = mcItem.CPSkill;
-        }
-
-        if (template is IStatEffectIncMountFatigue fatigueItem && fatigueItem.IncFatigue != 0)
-        {
-            fatigue = fatigueItem.IncFatigue;
-        }
-
-        if (template is IItemStatEffectMobSkill mobSkillItem && mobSkillItem.MobSkill != null)
-        {
-            mobSkill = (short)mobSkillItem.MobSkill.MobSkill;
-            mobSkillLevel = (short)mobSkillItem.MobSkill.Level;
-            target = (short)mobSkillItem.MobSkill.Target;
         }
 
         if (template is IStatEffectMorphGhost morphGhost)
         {
-            ghost = morphGhost.Ghost;
-            addBuffStatPairToListIfNotZero(statups, BuffStat.GHOST_MORPH, ghost);
+            addBuffStatPairToListIfNotZero(statups, BuffStat.GHOST_MORPH, morphGhost.Ghost);
         }
 
         if (template is IStatEffectMorph morphEffect)
@@ -272,11 +260,6 @@ public class StatEffect
             morphId = morphEffect.Morph;
             hp = (short)morphEffect.HP;
             addBuffStatPairToListIfNotZero(statups, BuffStat.MORPH, morphId);
-        }
-
-        if (template is TownScrollItemTemplate scroll)
-        {
-            moveTo = scroll.MoveTo;
         }
 
         if (template is CouponItemTemplate coupon)
@@ -323,20 +306,16 @@ public class StatEffect
 
         if (template is PotionItemTemplate other)
         {
-            barrier = other.Barrier;
-            berserk = other.Berserk;
-            booster = other.Booster;
-
-            addBuffStatPairToListIfNotZero(statups, BuffStat.AURA, barrier);
-            addBuffStatPairToListIfNotZero(statups, BuffStat.BERSERK, berserk);
-            addBuffStatPairToListIfNotZero(statups, BuffStat.BOOSTER, booster);
+            addBuffStatPairToListIfNotZero(statups, BuffStat.AURA, other.Barrier);
+            addBuffStatPairToListIfNotZero(statups, BuffStat.BERSERK, other.Berserk);
+            addBuffStatPairToListIfNotZero(statups, BuffStat.BOOSTER, other.Booster);
         }
 
         {
-            int prob = 0;
             if (template is MonsterCardItemTemplate mobCard)
             {
-                // TODO: 这4个效果加成功能似乎没有实现
+                Prob = mobCard.Prob;
+                // 客户端计算
                 if (mobCard.RespectPimmune)
                 {
                     addBuffStatPairToListIfNotZero(statups, BuffStat.RESPECT_PIMMUNE, mobCard.Prob);
@@ -358,7 +337,6 @@ public class StatEffect
                     DefenseState = mobCard.DefenseState;
                     addBuffStatPairToListIfNotZero(statups, BuffStat.DEFENSE_STATE, mobCard.Prob);
                 }
-                prob = mobCard.Prob;
 
                 foreach (var conData in mobCard.Con)
                 {
@@ -368,32 +346,16 @@ public class StatEffect
 
             if (template is IItemStatEffectMesoUp mesoUp && mesoUp.MesoUp)
             {
+                Prob = mesoUp.Prob;
                 // 为什么是4？
                 // 改成prob，当存在多个有效buff时，取用倍率最高的
                 addBuffStatPairToListIfNotZero(statups, BuffStat.MESO_UP_BY_ITEM, mesoUp.Prob);
-                prob = mesoUp.Prob;
             }
 
             if (template is IItemStatEffectItemUp itemUp && itemUp.ItemUp > 0)
             {
+                Prob = itemUp.Prob;
                 addBuffStatPairToListIfNotZero(statups, BuffStat.ITEM_UP_BY_ITEM, itemUp.Prob);
-                prob = itemUp.Prob;
-
-                switch (itemUp.ItemUp)
-                {
-                    case 2:
-                        _itemCode = itemUp.ItemCode;
-                        break;
-
-                    case 3:
-                        _itemRange = itemUp.ItemRange;    // 3 digits
-                        break;
-                }
-            }
-
-            if (prob > 0)
-            {
-                Prob = prob;
             }
         }
 
@@ -828,7 +790,6 @@ public class StatEffect
         }
 
 
-
         statups.TrimExcess();
     }
 
@@ -961,21 +922,21 @@ public class StatEffect
             return false;
         }
 
-        if (moveTo != -1)
+        if (EffectTemplate is TownScrollItemTemplate townScroll)
         {
-            if (moveTo != applyto.getMapId())
+            if (townScroll.MoveTo != applyto.getMapId())
             {
                 IMap target;
                 Portal pt;
 
-                if (moveTo == MapId.NONE)
+                if (townScroll.MoveTo == MapId.NONE)
                 {
                     target = applyto.getMap().getReturnMap();
                     pt = target.getRandomPlayerSpawnpoint();
                 }
                 else
                 {
-                    target = applyto.getChannelServer().getMapFactory().getMap(moveTo);
+                    target = applyto.getChannelServer().getMapFactory().getMap(townScroll.MoveTo);
                     int targetid = target.getId() / 10000000;
                     if (targetid != 60
                         && applyto.getMapId() / 10000000 != 61
@@ -1057,14 +1018,62 @@ public class StatEffect
             applyto.Monsterbook.addCard(monsterCardItem.TemplateId);
         }
 
-        if (cp != 0)
+        if (EffectTemplate is IItemStatEffectMC mc)
         {
-            applyto.gainCP(cp);
+            if (mc.CP != 0)
+            {
+                applyto.gainCP(mc.CP);
+            }
+
+            if (mc.CPSkill != 0 && applyto.Party > 0 && applyto.getMap().isCPQMap())
+            {
+                // added by Drago (Dragohe4rt)
+                var skill = CarnivalFactory.getInstance().getSkill(mc.CPSkill);
+                if (skill != null)
+                {
+                    var dis = skill.getDisease();
+                    var opposition = applyfrom.MCTeam!.Enemy!;
+                    if (skill.targetsAll)
+                    {
+                        foreach (var chrApp in opposition.Team.EligibleMembers)
+                        {
+                            if (chrApp.IsOnlined && chrApp.getMap().isCPQMap())
+                            {
+                                if (dis == null)
+                                {
+                                    chrApp.dispel();
+                                }
+                                else
+                                {
+                                    MobSkill mobSkill = skill.getSkill();
+                                    chrApp.giveDebuff(dis, mobSkill);
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        var chrApp = applyfrom.getMap().getCharacterById(opposition.GetRandomMemberId());
+                        if (chrApp != null && chrApp.getMap().isCPQMap())
+                        {
+                            if (dis == null)
+                            {
+                                chrApp.dispel();
+                            }
+                            else
+                            {
+                                MobSkill mobSkill = skill.getSkill();
+                                chrApp.giveDebuff(dis, mobSkill);
+                            }
+                        }
+                    }
+                }
+            }
         }
 
-        if (applyto.MountModel != null && this.getFatigue() != 0)
+        if (EffectTemplate is IStatEffectIncMountFatigue mountFatigue && mountFatigue.IncFatigue != 0 && applyto.MountModel != null)
         {
-            applyto.MountModel.setTiredness(applyto.MountModel.getTiredness() + this.getFatigue());
+            applyto.MountModel.setTiredness(applyto.MountModel.getTiredness() + mountFatigue.IncFatigue);
         }
 
         if (summonMovementType != null && pos != null)
@@ -1122,51 +1131,6 @@ public class StatEffect
         {
             applyto.removeAllCooldownsExcept(Buccaneer.TIME_LEAP, true);
         }
-        else if (nuffSkill != 0 && applyto.Party > 0 && applyto.getMap().isCPQMap())
-        {
-            // added by Drago (Dragohe4rt)
-            var skill = CarnivalFactory.getInstance().getSkill(nuffSkill);
-            if (skill != null)
-            {
-                var dis = skill.getDisease();
-                var opposition = applyfrom.MCTeam!.Enemy!;
-                if (skill.targetsAll)
-                {
-                    foreach (var chrApp in opposition.Team.EligibleMembers)
-                    {
-                        if (chrApp.IsOnlined && chrApp.getMap().isCPQMap())
-                        {
-                            if (dis == null)
-                            {
-                                chrApp.dispel();
-                            }
-                            else
-                            {
-                                MobSkill mobSkill = skill.getSkill();
-                                chrApp.giveDebuff(dis, mobSkill);
-                            }
-                        }
-                    }
-                }
-                else
-                {
-
-                    var chrApp = applyfrom.getMap().getCharacterById(opposition.GetRandomMemberId());
-                    if (chrApp != null && chrApp.getMap().isCPQMap())
-                    {
-                        if (dis == null)
-                        {
-                            chrApp.dispel();
-                        }
-                        else
-                        {
-                            MobSkill mobSkill = skill.getSkill();
-                            chrApp.giveDebuff(dis, mobSkill);
-                        }
-                    }
-                }
-            }
-        }
         else if (cureDebuffs.Count > 0)
         { // added by Drago (Dragohe4rt)
             foreach (Disease debuff in cureDebuffs)
@@ -1174,13 +1138,13 @@ public class StatEffect
                 applyfrom.dispelDebuff(debuff);
             }
         }
-        else if (mobSkill > 0 && mobSkillLevel > 0)
+        else if (EffectTemplate is IItemStatEffectMobSkill mobSkillEffect && mobSkillEffect.MobSkill != null)
         {
-            MobSkillType mobSkillType = MobSkillTypeUtils.from(mobSkill);
-            MobSkill ms = MobSkillFactory.getMobSkillOrThrow(mobSkillType, mobSkillLevel);
+            MobSkillType mobSkillType = MobSkillTypeUtils.from(mobSkillEffect.MobSkill.MobSkill);
+            MobSkill ms = MobSkillFactory.getMobSkillOrThrow(mobSkillType, mobSkillEffect.MobSkill.Level);
             var dis = Disease.GetBySkillTrust(mobSkillType);
 
-            if (target > 0)
+            if (mobSkillEffect.MobSkill.Target > 0)
             {
                 foreach (Player chr in applyto.getMap().getAllPlayers())
                 {
@@ -1416,6 +1380,18 @@ public class StatEffect
                 if (localstatups[i].BuffState.Equals(BuffStat.MORPH))
                 {
                     localstatups[i] = new(BuffStat.MORPH, getMorph(applyto));
+                    break;
+                }
+            }
+        }
+        else if (EffectTemplate is IStatEffectMorph morph && morph.MorphRandom?.Length > 0)
+        {
+            var item = new LotteryMachine<MorphRandomData, int>(morph.MorphRandom.ToList(), x => x.Prob).GetRandomItem();
+            for (int i = 0; i < localstatups.Length; i++)
+            {
+                if (localstatups[i].BuffState.Equals(BuffStat.MORPH))
+                {
+                    localstatups[i] = new(BuffStat.MORPH, item.Morph);
                     break;
                 }
             }
@@ -1973,16 +1949,6 @@ public class StatEffect
     private bool isComboReset()
     {
         return sourceid == Aran.COMBO_BARRIER || sourceid == Aran.COMBO_DRAIN;
-    }
-
-    private int getFatigue()
-    {
-        return fatigue;
-    }
-
-    private int getMorph()
-    {
-        return morphId;
     }
 
     private int getMorph(Player chr)

--- a/src/Application.Core/tools/PacketCreator.cs
+++ b/src/Application.Core/tools/PacketCreator.cs
@@ -519,8 +519,10 @@ public class PacketCreator
                 p.writeInt(skill.Value.masterlevel);
             }
         }
-        p.writeShort(chr.getAllCooldowns().Count);
-        foreach (PlayerCoolDownValueHolder cooling in chr.getAllCooldowns())
+
+        var cooldowns = chr.getAllCooldowns();
+        p.writeShort(cooldowns.Count);
+        foreach (var cooling in cooldowns)
         {
             p.writeInt(cooling.skillId);
             int timeLeft = (int)(cooling.length + cooling.startTime - chr.Client.CurrentServer.Node.getCurrentTime());

--- a/src/Application.Shared/Constants/Skill/Corsair.cs
+++ b/src/Application.Shared/Constants/Skill/Corsair.cs
@@ -37,4 +37,6 @@ public class Corsair
     public const int HYPNOTIZE = 5221009;
     public const int SPEED_INFUSION = 5221010;
     public const int BULLSEYE = 5220011;
+
+    public const int BATTLE_SHIP_HP = 5221999;
 }

--- a/src/Application.Shared/GameProps/Disease.cs
+++ b/src/Application.Shared/GameProps/Disease.cs
@@ -62,7 +62,6 @@ namespace Application.Shared.GameProps
         private ulong i;
         private MobSkillType mobSkillType;
         bool _isFirst;
-        private string Ab { get; }
 
         Disease(ulong i) : this(i, 0)
         {

--- a/src/Application.Templates/Item/Consume/MonsterCardItemTemplate.cs
+++ b/src/Application.Templates/Item/Consume/MonsterCardItemTemplate.cs
@@ -6,7 +6,11 @@ namespace Application.Templates.Item.Consume
     /// 238
     /// </summary>
     [GenerateTag]
-    public class MonsterCardItemTemplate : PotionItemTemplate, IStatEffectMapProtection
+    public class MonsterCardItemTemplate : PotionItemTemplate, 
+        IStatEffectMapProtection, 
+        IItemStatEffectMesoUp,
+        IItemStatEffectItemUp,
+        IStatEffectPower
     {
         public MonsterCardItemTemplate(int templateId) : base(templateId)
         {

--- a/test/ServiceTest/Infrastructure/TemporaryStatType.cs
+++ b/test/ServiceTest/Infrastructure/TemporaryStatType.cs
@@ -1,18 +1,18 @@
 using Application.Shared.GameProps;
 using Application.Utility;
 
-namespace ServiceTest.Games.Gameplay
+namespace ServiceTest.Infrastructure
 {
     public class TempDe
     {
-        // [Test]
+        [Test]
         public void P1()
         {
             var n = Enum.GetValues<TemporaryStatType>();
             List<PosValuePair> ns = [];
             foreach (var item in n)
             {
-                ns.Add(new(item.ToString(), 3 - ((int)item / 32), (int)(((long)1 << ((int)item % 32)) & 0xFFFFFFFF), false));
+                ns.Add(new(item.ToString(), 3 - ((int)item / 32), (uint)(((long)1 << ((int)item % 32)) & 0xFFFFFFFF), false));
             }
 
             var o = EnumClassCache<BuffStat>.GetValues();
@@ -20,42 +20,42 @@ namespace ServiceTest.Games.Gameplay
             List<PosValuePair> os = [];
             foreach (var item in o)
             {
-                var high = (int)(item.getValue() >> 32);
-                var low = (int)(item.getValue() & 0xFFFFFFFF);
+                var high = (uint)(item.getValue() >> 32);
+                var low = (uint)(item.getValue() & 0xFFFFFFFF);
 
                 int pos = low != 0 ? 2 : 3;
                 if (item.IsFirst)
                 {
                     pos -= 2;
                 }
-                int value = low > 0 ? low : high;
+                var value = low > 0 ? low : high;
                 os.Add(new PosValuePair(item.name(), pos, value, false));
 
             }
             foreach (var item in d)
             {
-                var high = (int)(item.getValue() >> 32);
-                var low = (int)(item.getValue() & 0xFFFFFFFF);
+                var high = (uint)(item.getValue() >> 32);
+                var low = (uint)(item.getValue() & 0xFFFFFFFF);
 
                 int pos = low != 0 ? 2 : 3;
                 if (item.isFirst())
                 {
                     pos -= 2;
                 }
-                int value = low > 0 ? low : high;
+                var value = low > 0 ? low : high;
                 os.Add(new PosValuePair(item.name(), pos, value, true));
             }
 
             Console.WriteLine("New================>");
             foreach (var item in ns.OrderBy(x => x.Position).ThenBy(x => x.Value))
             {
-                Console.WriteLine($"{item.Name}: Pos: {item.Position}, Value: {item.Value}");
+                Console.WriteLine($"{item.Name}: Pos: {item.Position}, Value: {(uint)item.Value}");
             }
 
             Console.WriteLine("Old================>");
             foreach (var item in os.OrderBy(x => x.Position).ThenBy(x => x.Value))
             {
-                var s = $"{item.Name}: Pos: {item.Position}, Value: {item.Value}";
+                var s = $"{item.Name}: Pos: {item.Position}, Value: {(uint)item.Value}";
                 if (item.IsDisease)
                 {
                     s += "  (From Disease)";
@@ -67,7 +67,7 @@ namespace ServiceTest.Games.Gameplay
         }
     }
 
-    public record PosValuePair(string Name, int Position, int Value, bool IsDisease);
+    public record PosValuePair(string Name, int Position, uint Value, bool IsDisease);
     public enum TemporaryStatType
     {
         WATK,


### PR DESCRIPTION
- 武装在受伤后切换频道，血量增加
- 无视免疫buff被反作弊阻止
- 同时拥有itemup和mesoup时，避免混淆加成（虽然并没有这种数据）
- 整理`StatEffect`，移除一些字段
- 修复随机变身