### PR TITLE
更新：插件

### DIFF
--- a/src/Application.Core/Channel/Net/Handlers/NPCMoreTalkHandler.cs
+++ b/src/Application.Core/Channel/Net/Handlers/NPCMoreTalkHandler.cs
@@ -50,7 +50,7 @@ public class NPCMoreTalkHandler : ChannelHandlerBase
                     else
                     {
                         // c.CurrentServer.NPCScriptManager.action(c, action, lastMsg, -1);
-                        _ = c.CurrentServer.NodeService.PluginManager.MoreNpcConversation(c, action, lastMsg, -1, returnText);
+                        _ = c.CurrentServer.NodeService.ScriptManager.MoreNpcConversation(c, action, lastMsg, -1, returnText);
                     }
                 }
             }
@@ -78,7 +78,7 @@ public class NPCMoreTalkHandler : ChannelHandlerBase
             else if (c.NPCConversationManager != null)
             {
                 // c.CurrentServer.NPCScriptManager.action(c, action, lastMsg, selection);
-                _ = c.CurrentServer.NodeService.PluginManager.MoreNpcConversation(c, action, lastMsg, selection);
+                _ = c.CurrentServer.NodeService.ScriptManager.MoreNpcConversation(c, action, lastMsg, selection);
             }
         }
     }

--- a/src/Application.Core/Channel/Net/Handlers/NPCTalkHandler.cs
+++ b/src/Application.Core/Channel/Net/Handlers/NPCTalkHandler.cs
@@ -94,7 +94,7 @@ public class NPCTalkHandler : ChannelHandlerBase
                 return;
             }
 
-            _ = c.CurrentServer.NodeService.PluginManager.StartNpcConversation(c, npc.getId(), npc, npc.SourceTemplate.Script);
+            _ = c.CurrentServer.NodeService.ScriptManager.StartNpcConversation(c, npc.getId(), npc, npc.SourceTemplate.Script);
             return;
 
             //if (npc.getId() == NpcId.DUEY)

--- a/src/Application.Core/Channel/Net/Handlers/QuestActionHandler.cs
+++ b/src/Application.Core/Channel/Net/Handlers/QuestActionHandler.cs
@@ -130,7 +130,7 @@ public class QuestActionHandler : ChannelHandlerBase
                     }
                     if (quest.canStart(player, npc))
                     {
-                        _ = c.CurrentServer.NodeService.PluginManager.ProcessQuestConversation(c, quest, npc, true);
+                        _ = c.CurrentServer.NodeService.ScriptManager.ProcessQuestConversation(c, quest, npc, true);
                         // c.CurrentServer.QuestScriptManager.start(c, questid, npc);
                     }
                     break;
@@ -144,7 +144,7 @@ public class QuestActionHandler : ChannelHandlerBase
                     }
                     if (quest.canComplete(player, npc))
                     {
-                        _ = c.CurrentServer.NodeService.PluginManager.ProcessQuestConversation(c, quest, npc, false);
+                        _ = c.CurrentServer.NodeService.ScriptManager.ProcessQuestConversation(c, quest, npc, false);
                         // c.CurrentServer.QuestScriptManager.end(c, questid, npc);
                     }
                     break;

--- a/src/Application.Core/Channel/Services/IServiceCenter.cs
+++ b/src/Application.Core/Channel/Services/IServiceCenter.cs
@@ -2,6 +2,7 @@ using Application.Core.Channel.DataProviders;
 using Application.Core.Channel.DueyService;
 using Application.Core.Channel.Modules;
 using Application.Core.Channel.ServerData;
+using Application.Core.Gameplay.Plugins;
 using Application.Core.Plugins;
 using Application.Shared.Servers;
 using System;
@@ -17,6 +18,7 @@ namespace Application.Core.Channel.Services
     public interface IServiceCenter
     {
         ChannelServerConfig ServerConfig { get; }
+        ScriptManager ScriptManager { get; }
         PluginManager PluginManager { get; }
         ITimerManager TimerManager { get; }
         IServiceProvider ServiceProvider { get; }

--- a/src/Application.Core/Channel/WorldChannel/WorldChannel.cs
+++ b/src/Application.Core/Channel/WorldChannel/WorldChannel.cs
@@ -253,7 +253,7 @@ public partial class WorldChannel : ISocketServer, IClientMessenger, INamedInsta
             return;
         }
 
-        NodeService.PluginManager.RegisterEvents(this);
+        NodeService.ScriptManager.RegisterEvents(this);
     }
     public async Task Initialize(Config.RegisterServerResult config)
     {
@@ -262,11 +262,6 @@ public partial class WorldChannel : ISocketServer, IClientMessenger, INamedInsta
         UpdateWorldConfig(config.Config);
         log.Information("[{ServerName}] 初始化世界倍率-完成。怪物倍率：x{MobRate}，金币倍率：x{MesoRate}，经验倍率：x{ExpRate}，掉落倍率：x{DropRate}，BOSS掉落倍率：x{BossDropRate}，任务倍率：x{QuestRate}，传送时间倍率：x{TravelRate}，钓鱼倍率：x{FishingRate}。",
             InstanceName, WorldMobRate, WorldMesoRate, WorldExpRate, WorldDropRate, WorldBossDropRate, WorldQuestRate, WorldTravelRate, WorldFishingRate);
-
-        log.Information("[{ServerName}] 初始化事件...", InstanceName);
-        var loadedEventsCount = NodeService.PluginManager.RegisterEvents(this);
-        // var loadedEventsCount = EventScriptManager.ReloadEventScript();
-        log.Information("[{ServerName}] 初始化事件（{EventCount}项）...完成", InstanceName, loadedEventsCount);
 
         TimerManager = await TimerManagerFactory.InitializeAsync(TaskEngine.Quartz, InstanceName);
 

--- a/src/Application.Core/Channel/WorldChannelServer.cs
+++ b/src/Application.Core/Channel/WorldChannelServer.cs
@@ -9,6 +9,7 @@ using Application.Core.Channel.ServerData;
 using Application.Core.Channel.Services;
 using Application.Core.Channel.Tasks;
 using Application.Core.Game.Skills;
+using Application.Core.Gameplay.Plugins;
 using Application.Core.Plugins;
 using Application.Core.ServerTransports;
 using Application.Shared.Login;
@@ -138,6 +139,7 @@ namespace Application.Core.Channel
         public CommandLoop<WorldChannelServer> CommandLoop { get; }
 
         public TickableStatus Status => throw new NotImplementedException();
+        public ScriptManager ScriptManager { get; }
         public PluginManager PluginManager { get; }
 
         public WorldChannelServer(IServiceProvider sp,
@@ -190,7 +192,8 @@ namespace Application.Core.Channel
             BatchSynMapManager = new BatchSyncManager<int, SyncProto.MapSyncDto>(50, 100, x => x.MasterId, data => Transport.BatchSyncMap(data));
             BatchSyncPlayerManager = new BatchSyncManager<int, SyncProto.PlayerSaveDto>(50, 100, x => x.Character.Id, data => Transport.BatchSyncPlayer(data));
 
-            PluginManager = new();
+            ScriptManager = new(this);
+            PluginManager = new(this);
 
             _messageDispatcher = new(() => new(this));
             CommandLoop = new (this);
@@ -270,6 +273,8 @@ namespace Application.Core.Channel
                 {
                     await server.Shutdown(delaySeconds);
                 }
+                await ScriptManager.DisposeAsync();
+                await PluginManager.DisposeAsync();
 
                 await TimerManager.Stop();
                 await CommandLoop.DisposeAsync();
@@ -334,18 +339,6 @@ namespace Application.Core.Channel
             OpcodeConstants.generateOpcodeNames();
             ForceUpdateServerTime();
 
-            try
-            {
-                watcher = new FileSystemWatcher(AppDomain.CurrentDomain.BaseDirectory, "*.dll") { NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size };
-                watcher.Changed += OnFileChanged;
-                watcher.EnableRaisingEvents = true;
-                await PluginManager.LoadPlugin("Application.Plugin.Script.dll");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError("注册服务器失败, {Message}", ex.Message);
-                return false;
-            }
 
             var channel = configs.StartChannel;
             foreach (var server in effectChannels)
@@ -359,6 +352,19 @@ namespace Application.Core.Channel
 
                 channel++;
                 await worldChannel.StartServer(cancellationToken);
+            }
+
+            try
+            {
+                watcher = new FileSystemWatcher(AppDomain.CurrentDomain.BaseDirectory, "Application.Plugin.*.dll") { NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size };
+                watcher.Changed += OnFileChanged;
+                watcher.EnableRaisingEvents = true;
+
+                await LoadAllPlugins();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("注册脚本失败, {Message}", ex.Message);
             }
 
             DataService.LoadAllPLife();
@@ -407,20 +413,58 @@ namespace Application.Core.Channel
 
         private DateTime _lastLoadTime = DateTime.MinValue;
 
+        private async Task LoadAllPlugins()
+        {
+            var pluginFiles = Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "Application.Plugin.*.dll");
+            foreach (var pluginFile in pluginFiles)
+            {
+                var pluginName = Path.GetFileName(pluginFile);
+                try
+                {
+                    if (IsScriptPlugin(pluginName))
+                    {
+                        _logger.LogInformation("加载脚本插件: {PluginName}", pluginName);
+                        await ScriptManager.LoadPlugin(pluginName);
+                    }
+                    else
+                    {
+                        _logger.LogInformation("加载普通插件: {PluginName}", pluginName);
+                        await PluginManager.LoadPlugin(pluginName);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "加载插件失败: {PluginName}", pluginName);
+                }
+            }
+        }
+
+        private bool IsScriptPlugin(string pluginName)
+        {
+            return pluginName.StartsWith("Application.Plugin.Script", StringComparison.OrdinalIgnoreCase);
+        }
+
         private async void OnFileChanged(object sender, FileSystemEventArgs e)
         {
-            if (e.Name != "Application.Plugin.Script.dll") return;
+            if (!e.Name.StartsWith("Application.Plugin.")) return;
 
-            // 简单的节流：1秒内只处理一次
             var now = DateTime.Now;
             if ((now - _lastLoadTime) < TimeSpan.FromSeconds(1))
                 return;
 
             _lastLoadTime = now;
 
-            await Task.Delay(200); // 等待文件释放
-            _logger.LogInformation("插件更新...");
-            await PluginManager.LoadPlugin("Application.Plugin.Script.dll");
+            await Task.Delay(200);
+            _logger.LogInformation("插件更新: {PluginName}", e.Name);
+
+            if (IsScriptPlugin(e.Name))
+            {
+                await ScriptManager.LoadPlugin(e.Name);
+            }
+            else
+            {
+                await PluginManager.LoadPlugin(e.Name);
+            }
         }
 
 

--- a/src/Application.Core/Game/Commands/CommandExecutor.cs
+++ b/src/Application.Core/Game/Commands/CommandExecutor.cs
@@ -41,6 +41,14 @@ public class CommandExecutor
         }
     }
 
+    public void TryRemoveCommand(CommandBase command)
+    {
+        foreach (var sytax in command.AllSupportedCommand)
+        {
+            registeredCommands.Remove(sytax);
+        }
+    }
+
     public void handle(IChannelClient client, string message)
     {
         if (!loaded)

--- a/src/Application.Core/Game/Life/Monster.cs
+++ b/src/Application.Core/Game/Life/Monster.cs
@@ -142,6 +142,7 @@ public class Monster : AbstractLifeObject, ICombatantObject, ILoopTickable
         base.OnMounted(map);
 
         DispatchMonsterSpawned();
+        map.ChannelServer.NodeService.PluginManager.OnMobSpawned(this);
         _recoverMPNext = map.ChannelServer.Node.getCurrentTime() + _recoverMPPeriod;
     }
 
@@ -485,6 +486,7 @@ public class Monster : AbstractLifeObject, ICombatantObject, ILoopTickable
         if (!fake)
         {
             OnDamaged?.Invoke(this, new MonsterDamagedEventArgs(from, trueDamage.Value));
+            MapModel.ChannelServer.NodeService.PluginManager.OnMobDamaged(this, trueDamage.Value, from);
         }
 
         if (getStats().isFriendly())
@@ -540,6 +542,7 @@ public class Monster : AbstractLifeObject, ICombatantObject, ILoopTickable
         maxHpPlusHeal.addAndGet(hpHealed.Value);
 
         OnHealed?.Invoke(this, hpHealed.Value);
+        MapModel.ChannelServer.NodeService.PluginManager.OnMobHealed(this, hpHealed.Value);
     }
 
     public bool isAttackedBy(Player chr)
@@ -1016,6 +1019,7 @@ public class Monster : AbstractLifeObject, ICombatantObject, ILoopTickable
 
         var dieAni = getAnimationTime("die1");
         OnKilled?.Invoke(this, new MonsterKilledEventArgs(killer, dieAni));
+        MapModel.ChannelServer.NodeService.PluginManager.OnMobKilled(this, killer);
 
         if (getStats().isFriendly())
         {

--- a/src/Application.Core/Game/Maps/AbstractMapObject.cs
+++ b/src/Application.Core/Game/Maps/AbstractMapObject.cs
@@ -85,11 +85,13 @@ public abstract class AbstractMapObject : IMapObject
     public virtual void OnMounted(IMap map)
     {
         MapModel = map;
+
+        map.ChannelServer.NodeService.PluginManager.OnMapObjectEnterField(map, this);
     }
 
     public virtual void OnUnmounted()
     {
-
+        MapModel.ChannelServer.NodeService.PluginManager.OnMapObjectLeaveField(MapModel, this);
     }
 
     /// <summary>

--- a/src/Application.Core/Game/Maps/IMapObject.cs
+++ b/src/Application.Core/Game/Maps/IMapObject.cs
@@ -21,7 +21,7 @@ namespace Application.Core.Game.Maps
         /// <param name="map"></param>
         void OnMounted(IMap map);
         /// <summary>
-        /// 从地图移除时
+        /// 从地图移除后
         /// </summary>
         void OnUnmounted();
         /// <summary>

--- a/src/Application.Core/Game/Maps/MapleMap.cs
+++ b/src/Application.Core/Game/Maps/MapleMap.cs
@@ -2667,7 +2667,7 @@ public class MapleMap : IMap, INamedInstance
         {
             if (!chr.hasEntered(Id))
             {
-                chr.getClient().CurrentServer.NodeService.PluginManager.MapFirstEnterScript(chr.getClient(), this);
+                chr.getClient().CurrentServer.NodeService.ScriptManager.MapFirstEnterScript(chr.getClient(), this);
                 chr.enteredScript(Id);
             }
         }
@@ -2679,7 +2679,7 @@ public class MapleMap : IMap, INamedInstance
                 chr.SaveLocation(SavedLocationType.INTRO);
             }
 
-            chr.getClient().CurrentServer.NodeService.PluginManager.MapEnterScript(chr.getClient(), this);
+            chr.getClient().CurrentServer.NodeService.ScriptManager.MapEnterScript(chr.getClient(), this);
         }
 
         if (FieldLimit.CANNOTUSEMOUNTS.check(SourceTemplate.FieldLimit) && chr.getBuffedValue(BuffStat.MONSTER_RIDING) != null)

--- a/src/Application.Core/Game/Players/Player.cs
+++ b/src/Application.Core/Game/Players/Player.cs
@@ -206,7 +206,7 @@ namespace Application.Core.Game.Players
             if (script != null)
             {
                 var npcObj = MapModel.getNPCById(npcId);
-                _ = Client.CurrentServer.NodeService.PluginManager.StartNpcConversation(Client, npcId, MapModel.getNPCById(npcId), script);
+                _ = Client.CurrentServer.NodeService.ScriptManager.StartNpcConversation(Client, npcId, MapModel.getNPCById(npcId), script);
             }
 
         }

--- a/src/Application.Core/Gameplay/Plugins/AbstractPluginManager.cs
+++ b/src/Application.Core/Gameplay/Plugins/AbstractPluginManager.cs
@@ -55,6 +55,12 @@ namespace Application.Core.Plugins
         {
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="pluginDllName"></param>
+        /// <param name="allowMulti">是否允许注册多个dll</param>
+        /// <returns></returns>
         protected async Task<bool> LoadPluginInternal(string pluginDllName, bool allowMulti)
         {
             var newContainer = LoadPluginFromSource(pluginDllName);
@@ -84,11 +90,12 @@ namespace Application.Core.Plugins
 
         async Task<bool> RemovePluginInternal(string pluginName)
         {
-            if (_pluginContainers.TryRemove(pluginName, out var container))
+            if (_pluginContainers.TryGetValue(pluginName, out var container))
             {
                 try
                 {
                     await container.DisposeAsync().ConfigureAwait(false);
+                    _pluginContainers.TryRemove(pluginName, out _);
                     return true;
                 }
                 catch (Exception ex)

--- a/src/Application.Core/Gameplay/Plugins/AbstractPluginManager.cs
+++ b/src/Application.Core/Gameplay/Plugins/AbstractPluginManager.cs
@@ -1,0 +1,204 @@
+using Application.Core.Channel;
+using Application.Core.Gameplay.Plugins;
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace Application.Core.Plugins
+{
+    /// <summary>
+    /// 插件管理器：负责加载、热更新、请求路由，支持多插件注册
+    /// </summary>
+    public abstract class AbstractPluginManager<TService> : IAsyncDisposable where TService : class, IPluginServiceBase
+    {
+        protected readonly string _sourcePluginDir;      // 运维放置插件 DLL 的源目录
+        protected readonly string _shadowCopyBaseDir;    // 卷影副本根目录（例如 "ShadowCopy"）
+
+        protected readonly ConcurrentDictionary<string, PluginContainer<TService>> _pluginContainers = new();
+        protected bool _disposed = false;
+
+        protected WorldChannelServer _server;
+        /// <summary>
+        /// 构造函数
+        /// </summary>
+        /// <param name="sourcePluginDir">源插件目录（运维可写）</param>
+        /// <param name="shadowCopyBaseDir">卷影副本根目录</param>
+        /// <param name="drainTimeout">排水超时</param>
+        public AbstractPluginManager(WorldChannelServer server)
+        {
+            _server = server;
+
+            _sourcePluginDir = AppDomain.CurrentDomain.BaseDirectory;
+            _shadowCopyBaseDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "PluginShadowCopy");
+        }
+
+
+        public virtual async Task<bool> LoadPlugin(string pluginDllName)
+        {
+            if (await LoadPluginInternal(pluginDllName, true))
+            {
+                OnPluginMounted(pluginDllName);
+                return true;
+            }
+            return false;
+        }
+
+        protected virtual void OnPluginMounted(string pluginDllName)
+        {
+            OnPluginContainerChanged();
+        }
+        protected virtual void OnPluginUnmounted(string pluginDllName)
+        {
+            OnPluginContainerChanged();
+        }
+
+        protected virtual void OnPluginContainerChanged()
+        {
+        }
+
+        protected async Task<bool> LoadPluginInternal(string pluginDllName, bool allowMulti)
+        {
+            var newContainer = LoadPluginFromSource(pluginDllName);
+            if (newContainer == null)
+                return false;
+
+            var pluginBaseKey = Path.GetFileNameWithoutExtension(pluginDllName);
+
+            string pluginKey = pluginBaseKey;
+
+            if (!allowMulti)
+            {
+                var exsitedKeys = _pluginContainers.Keys.ToArray();
+                foreach (var item in exsitedKeys)
+                {
+                    await RemovePluginInternal(item);
+                }
+            }
+            else
+            {
+                await RemovePluginInternal(pluginKey);
+            }
+
+            _pluginContainers[pluginKey] = newContainer;
+            return true;
+        }
+
+        async Task<bool> RemovePluginInternal(string pluginName)
+        {
+            if (_pluginContainers.TryRemove(pluginName, out var container))
+            {
+                try
+                {
+                    await container.DisposeAsync().ConfigureAwait(false);
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    Log.Logger.Error($"Failed to unload plugin {pluginName}: {ex.Message}");
+                }
+            }
+            return false;
+        }
+
+        public virtual async Task<bool> UnloadPlugin(string pluginName)
+        {
+            if (await RemovePluginInternal(pluginName))
+            {
+                OnPluginUnmounted(pluginName);
+                return true;
+            }
+            return false;
+        }
+
+        public List<TService> GetAllPlugins()
+        {
+            return _pluginContainers.Values.SelectMany(c => c.PluginServices).ToList();
+        }
+
+        public PluginContainer<TService>? GetPluginContainer(string pluginName)
+        {
+            _pluginContainers.TryGetValue(pluginName, out var container);
+            return container;
+        }
+
+        public bool HasPlugin(string pluginName)
+        {
+            return _pluginContainers.ContainsKey(pluginName);
+        }
+
+        public int PluginCount => _pluginContainers.Count;
+
+        /// <summary>
+        /// 从源目录复制 DLL 到卷影副本，并加载
+        /// </summary>
+        private PluginContainer<TService> LoadPluginFromSource(string pluginDllName)
+        {
+            string sourcePath = Path.Combine(_sourcePluginDir, pluginDllName);
+            if (!File.Exists(sourcePath))
+                throw new FileNotFoundException($"Plugin not found: {sourcePath}");
+
+            // 创建唯一的卷影副本目录
+            string shadowDir = Path.Combine(_shadowCopyBaseDir, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(shadowDir);
+
+            string shadowDllPath = Path.Combine(shadowDir, pluginDllName);
+            File.Copy(sourcePath, shadowDllPath, overwrite: true);
+
+            // 创建自定义加载上下文
+            var loadContext = new PluginLoadContext(shadowDllPath);
+
+            // 加载插件程序集
+            Assembly pluginAssembly;
+            try
+            {
+                pluginAssembly = loadContext.LoadFromAssemblyPath(shadowDllPath);
+            }
+            catch (Exception ex)
+            {
+                // 加载失败，清理目录
+                Directory.Delete(shadowDir, recursive: true);
+                throw new InvalidOperationException($"Failed to load plugin from {shadowDllPath}", ex);
+            }
+
+            var serviceType = typeof(TService);
+
+            var pluginServiceTypes = pluginAssembly.GetTypes()
+                .Where(t => serviceType.IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract).ToList();
+
+            if (pluginServiceTypes.Count == 0)
+            {
+                loadContext.Unload();
+                Directory.Delete(shadowDir, recursive: true);
+                throw new InvalidOperationException($"No type implementing {serviceType.Name} found in {pluginDllName}");
+            }
+
+            var services = pluginServiceTypes.Select(x => (TService?)Activator.CreateInstance(x)).OfType<TService>().ToList();
+            return new PluginContainer<TService>(services, loadContext, shadowDir);
+        }
+
+        /// <summary>
+        /// 释放管理器：卸载所有已加载的插件
+        /// </summary>
+        public virtual async ValueTask DisposeAsync()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+
+            var containers = _pluginContainers.Values.ToList();
+            _pluginContainers.Clear();
+
+            foreach (var container in containers)
+            {
+                try
+                {
+                    await container.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Log.Logger.Error($"Failed to dispose plugin container: {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/src/Application.Core/Gameplay/Plugins/IPluginLifeService.cs
+++ b/src/Application.Core/Gameplay/Plugins/IPluginLifeService.cs
@@ -1,0 +1,13 @@
+using Application.Core.Channel;
+
+namespace Application.Core.Gameplay.Plugins
+{
+    public interface IPluginLifeService : IPluginServiceBase
+    {
+        void OnMounted(WorldChannelServer node);
+        void OnUnmounted(WorldChannelServer node);
+
+        void OnChannelMounted(WorldChannel channel);
+        void OnChannelUnmounted(WorldChannel channel);
+    }
+}

--- a/src/Application.Core/Gameplay/Plugins/IPluginMapService.cs
+++ b/src/Application.Core/Gameplay/Plugins/IPluginMapService.cs
@@ -1,0 +1,10 @@
+using Application.Core.Game.Maps;
+
+namespace Application.Core.Gameplay.Plugins
+{
+    public interface IPluginMapService : IPluginServiceBase
+    {
+        void OnMapObjectEnterField(IMap map, IMapObject mapObject);
+        void OnMapObjectLeaveField(IMap map, IMapObject mapObject);
+    }
+}

--- a/src/Application.Core/Gameplay/Plugins/IPluginMobService.cs
+++ b/src/Application.Core/Gameplay/Plugins/IPluginMobService.cs
@@ -1,0 +1,13 @@
+using Application.Core.Game.Life;
+using Application.Core.Game.Maps;
+
+namespace Application.Core.Gameplay.Plugins
+{
+    public interface IPluginMobService : IPluginServiceBase
+    {
+        void OnMobSpawned(Monster mob);
+        void OnMobHealed(Monster mob, int value);
+        void OnMobKilled(Monster mob, ICombatantObject? killer);
+        void OnMobDamaged(Monster mob, int damage, ICombatantObject? attacker);
+    }
+}

--- a/src/Application.Core/Gameplay/Plugins/IPluginServiceBase.cs
+++ b/src/Application.Core/Gameplay/Plugins/IPluginServiceBase.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Application.Core.Gameplay.Plugins
+{
+    public interface IPluginServiceBase: IAsyncDisposable
+    {
+    }
+}

--- a/src/Application.Core/Gameplay/Plugins/IScriptService.cs
+++ b/src/Application.Core/Gameplay/Plugins/IScriptService.cs
@@ -6,7 +6,7 @@ using server.maps;
 
 namespace Application.Core.Gameplay.Plugins
 {
-    public interface IScriptService: IAsyncDisposable
+    public interface IScriptService: IAsyncDisposable, IPluginServiceBase
     {
         #region Portal
         bool Enter(IChannelClient c, Portal p);

--- a/src/Application.Core/Gameplay/Plugins/PluginContainer.cs
+++ b/src/Application.Core/Gameplay/Plugins/PluginContainer.cs
@@ -1,23 +1,20 @@
 using Application.Core.Plugins;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Application.Core.Gameplay.Plugins
 {
     /// <summary>
     /// 插件包装器：包含插件实例、加载上下文、请求跟踪器
     /// </summary>
-    internal sealed class PluginContainer : IAsyncDisposable
+    public sealed class PluginContainer<TService> : IAsyncDisposable where TService : class, IPluginServiceBase
     {
-        public IScriptService Instance { get; }
+        public List<TService> PluginServices { get; }
         public PluginLoadContext LoadContext { get; }
         public RequestTracker Tracker { get; } = new();
         public string ShadowCopyPath { get; }
 
-        public PluginContainer(IScriptService instance, PluginLoadContext context, string shadowCopyPath)
+        public PluginContainer(List<TService> pluginServices, PluginLoadContext context, string shadowCopyPath)
         {
-            Instance = instance;
+            PluginServices = pluginServices;
             LoadContext = context;
             ShadowCopyPath = shadowCopyPath;
         }
@@ -25,7 +22,10 @@ namespace Application.Core.Gameplay.Plugins
         public async ValueTask DisposeAsync()
         {
             await Tracker.DisposeAsync();
-            await Instance.DisposeAsync();
+            foreach (var item in PluginServices)
+            {
+                await item.DisposeAsync();
+            }
             LoadContext.Unload();
             Log.Logger.Information("插件卸载完成");
             // 清理卷影副本目录

--- a/src/Application.Core/Gameplay/Plugins/PluginManager.cs
+++ b/src/Application.Core/Gameplay/Plugins/PluginManager.cs
@@ -1,395 +1,169 @@
 using Application.Core.Channel;
 using Application.Core.Game.Life;
 using Application.Core.Game.Maps;
-using Application.Core.Gameplay.Plugins;
-using OpenTelemetry.Trace;
-using server.maps;
-using System.ComponentModel;
-using System.Reflection;
-using System.Threading.Tasks;
+using Application.Core.Plugins;
+using System.Collections.Immutable;
 
-namespace Application.Core.Plugins
+namespace Application.Core.Gameplay.Plugins
 {
     /// <summary>
-    /// 插件管理器：负责加载、热更新、请求路由
+    /// 常规插件
     /// </summary>
-    public sealed class PluginManager : IAsyncDisposable
+    public sealed class PluginManager : AbstractPluginManager<IPluginServiceBase>
     {
-        private readonly string _sourcePluginDir;      // 运维放置插件 DLL 的源目录
-        private readonly string _shadowCopyBaseDir;    // 卷影副本根目录（例如 "ShadowCopy"）
+        private volatile ImmutableList<IPluginMobService> _mobListeners = ImmutableList<IPluginMobService>.Empty;
+        private volatile ImmutableList<IPluginMapService> _mapListeners = ImmutableList<IPluginMapService>.Empty;
+        private volatile ImmutableList<IPluginLifeService> _lifeListeners = ImmutableList<IPluginLifeService>.Empty;
 
-        private volatile PluginContainer? _currentContainer;
-        private bool _disposed = false;
-
-        /// <summary>
-        /// 构造函数
-        /// </summary>
-        /// <param name="sourcePluginDir">源插件目录（运维可写）</param>
-        /// <param name="shadowCopyBaseDir">卷影副本根目录</param>
-        /// <param name="drainTimeout">排水超时</param>
-        public PluginManager()
+        public PluginManager(WorldChannelServer server) : base(server)
         {
-            _sourcePluginDir = AppDomain.CurrentDomain.BaseDirectory;
-            _shadowCopyBaseDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "PluginShadowCopy");
         }
 
-
-        public async Task<bool> LoadPlugin(string pluginDllName)
+        protected override void OnPluginContainerChanged()
         {
-            // 1. 加载新插件（新上下文）
-            var newContainer = LoadPluginFromSourceAsync(pluginDllName);
-            if (newContainer == null)
-                return false;
+            DiscoverListeners();
+        }
 
-            PluginContainer? oldContainer = _currentContainer;
-            _currentContainer = newContainer;
+        protected override void OnPluginMounted(string pluginDllName)
+        {
+            base.OnPluginMounted(pluginDllName);
 
-            // 2. 排水并卸载旧插件（如果存在）
-            if (oldContainer != null)
+            foreach (var listener in _lifeListeners)
             {
                 try
                 {
-                    await oldContainer.DisposeAsync().ConfigureAwait(false);
+                    listener.OnMounted(_server);
                 }
                 catch (Exception ex)
                 {
-                    // 记录日志，但新插件已经生效，旧插件可能泄漏
-                    // 这里可以记录到 ILogger
-                    Log.Logger.Error($"Failed to unload old plugin: {ex.Message}");
-                    return false;
+                    Log.Logger.Error(ex, "插件{PluginName}.OnMounted 失败");
                 }
             }
-
-            return true;
         }
 
-        #region Services
-        public async Task<bool> StartNpcConversation(IChannelClient c, int npcId, NPC? npcObject, string? scriptName)
+        protected override void OnPluginUnmounted(string pluginDllName)
         {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(PluginManager));
+            base.OnPluginUnmounted(pluginDllName);
 
-            PluginContainer? container = _currentContainer;
-
-            if (container == null)
-                throw new InvalidOperationException("No plugin loaded");
-
-            using var _ = container.Tracker.EnterRequest();
-            try
+            foreach (var listener in _lifeListeners)
             {
-                return await container.Instance.Start(c, npcId, npcObject, scriptName);
-            }
-            catch (Exception e)
-            {
-                if (e is BusinessException)
+                try
                 {
-                    c.OnlinedCharacter.Pink(e.Message);
+                    listener.OnUnmounted(_server);
                 }
-                Log.Logger.Error(e, "Npc script error in: {ScriptName}", scriptName);
-                return false;
-            }
-        }
-
-        public async Task<bool> ProcessQuestConversation(IChannelClient c, server.quest.Quest questObj, int npcId, bool isStart)
-        {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(PluginManager));
-
-            PluginContainer? container = _currentContainer;
-
-            if (container == null)
-                throw new InvalidOperationException("No plugin loaded");
-
-            using var _ = container.Tracker.EnterRequest();
-            try
-            {
-                if (isStart)
+                catch (Exception ex)
                 {
-                    return await container.Instance.StartQuest(c, questObj, npcId);
+                    Log.Logger.Error(ex, "插件{PluginName}.OnUnmounted 初始化失败");
                 }
-                else
+            }
+        }
+
+        private void DiscoverListeners()
+        {
+            var mobListenersBuilder = ImmutableList.CreateBuilder<IPluginMobService>();
+            var mapListenersBuilder = ImmutableList.CreateBuilder<IPluginMapService>();
+            var commandListenersBuilder = ImmutableList.CreateBuilder<IPluginLifeService>();
+            foreach (var plugin in GetAllPlugins())
+            {
+                if (plugin is IPluginMobService mobListener)
+                    mobListenersBuilder.Add(mobListener);
+                if (plugin is IPluginMapService mapListener)
+                    mapListenersBuilder.Add(mapListener);
+                if (plugin is IPluginLifeService commandListener)
+                    commandListenersBuilder.Add(commandListener);
+            }
+            _mobListeners = mobListenersBuilder.ToImmutable();
+            _mapListeners = mapListenersBuilder.ToImmutable();
+            _lifeListeners = commandListenersBuilder.ToImmutable();
+        }
+
+        public void OnMobSpawned(Monster mob)
+        {
+            foreach (var listener in _mobListeners)
+            {
+                try
                 {
-                    return await container.Instance.CompleteQuest(c, questObj, npcId);
+                    listener.OnMobSpawned(mob);
                 }
-            }
-            catch (Exception e)
-            {
-                if (e is BusinessException)
+                catch (Exception ex)
                 {
-                    c.OnlinedCharacter.Pink(e.Message);
+                    Log.Logger.Error(ex, "MobListener.OnMobSpawned error");
                 }
-                Log.Logger.Error(e, "Quest script error in: QuestId={QuestId}", questObj.getId());
-                return false;
             }
         }
 
-        public async Task MoreNpcConversation(IChannelClient c, sbyte mode, sbyte type, int selection, string? inputText = null)
+        public void OnMobHealed(Monster mob, int value)
         {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(PluginManager));
-
-            PluginContainer? container = _currentContainer;
-
-            if (container == null)
-                throw new InvalidOperationException("No plugin loaded");
-
-            using var _ = container.Tracker.EnterRequest();
-            try
+            foreach (var listener in _mobListeners)
             {
-                await container.Instance.Action(c, mode, type, selection, inputText);
-            }
-            catch (Exception e)
-            {
-                if (e is BusinessException)
+                try
                 {
-                    c.OnlinedCharacter.Pink(e.Message);
+                    listener.OnMobHealed(mob, value);
                 }
-                Log.Logger.Error(e, "Npc script error in: {ScriptName}");
-            }
-        }
-
-        public bool EnterPortal(IChannelClient c, Portal p)
-        {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(PluginManager));
-
-            PluginContainer? container = _currentContainer;
-
-            if (container == null)
-                throw new InvalidOperationException("No plugin loaded");
-
-            using var _ = container.Tracker.EnterRequest();
-            try
-            {
-                return container.Instance.Enter(c, p);
-            }
-            catch (Exception e)
-            {
-                if (e is BusinessException)
+                catch (Exception ex)
                 {
-                    c.OnlinedCharacter.Pink(e.Message);
+                    Log.Logger.Error(ex, "MobListener.OnMobHealed error");
                 }
-                Log.Logger.Error(e, "Portal script error in: {ScriptName}", p.getScriptName());
             }
-            return false;
-
-
         }
-        public async Task ItemScript(IChannelClient c, int npcId, string scriptName)
+
+        public void OnMobKilled(Monster mob, ICombatantObject? killer)
         {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(PluginManager));
-
-            PluginContainer? container = _currentContainer;
-
-            if (container == null)
-                throw new InvalidOperationException("No plugin loaded");
-
-            using var _ = container.Tracker.EnterRequest();
-            try
+            foreach (var listener in _mobListeners)
             {
-                await container.Instance.ItemScript(c, npcId, scriptName);
-            }
-            catch (Exception e)
-            {
-                if (e is BusinessException)
+                try
                 {
-                    c.OnlinedCharacter.Pink(e.Message);
+                    listener.OnMobKilled(mob, killer);
                 }
-                Log.Logger.Error(e, "Item script error in: {ScriptName}", scriptName);
-            }
-        }
-
-
-        public void MapEnterScript(IChannelClient c, IMap map)
-        {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(PluginManager));
-
-            PluginContainer? container = _currentContainer;
-
-            if (container == null)
-                throw new InvalidOperationException("No plugin loaded");
-
-            using var _ = container.Tracker.EnterRequest();
-            try
-            {
-                container.Instance.MapEnter(c, map);
-            }
-            catch (Exception e)
-            {
-                if (e is BusinessException)
+                catch (Exception ex)
                 {
-                    c.OnlinedCharacter.Pink(e.Message);
+                    Log.Logger.Error(ex, "MobListener.OnMobKilled error");
                 }
-                Log.Logger.Error(e, "Map script error in: {Map}(Enter)", map.Id);
             }
         }
 
-        public void MapFirstEnterScript(IChannelClient c, IMap map)
+        public void OnMobDamaged(Monster mob, int damage, ICombatantObject? attacker)
         {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(PluginManager));
-
-            PluginContainer? container = _currentContainer;
-
-            if (container == null)
-                throw new InvalidOperationException("No plugin loaded");
-
-            using var _ = container.Tracker.EnterRequest();
-            try
+            foreach (var listener in _mobListeners)
             {
-                container.Instance.MapFirstEnter(c, map);
-            }
-            catch (Exception e)
-            {
-                if (e is BusinessException)
+                try
                 {
-                    c.OnlinedCharacter.Pink(e.Message);
+                    listener.OnMobDamaged(mob, damage, attacker);
                 }
-                Log.Logger.Error(e, "Map script error in: {Map}(FirstEnter)", map.Id);
-            }
-        }
-        internal void ReactorHit(IChannelClient c, Reactor reactor)
-        {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(PluginManager));
-
-            PluginContainer? container = _currentContainer;
-
-            if (container == null)
-                throw new InvalidOperationException("No plugin loaded");
-
-            using var _ = container.Tracker.EnterRequest();
-            try
-            {
-                container.Instance.ReactorHit(c, reactor).ConfigureAwait(false).GetAwaiter().GetResult();
-            }
-            catch (Exception e)
-            {
-                if (e is BusinessException)
+                catch (Exception ex)
                 {
-                    c.OnlinedCharacter.Pink(e.Message);
+                    Log.Logger.Error(ex, "MobListener.OnMobDamaged error");
                 }
-                Log.Logger.Error(e, "Reactor script error in: Map={Map}.Reactor={Reactor}", reactor.getMap().Id, reactor.getId());
             }
         }
-        internal void ReactorAct(IChannelClient c, Reactor reactor)
+
+        public void OnMapObjectEnterField(IMap map, IMapObject mapObject)
         {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(PluginManager));
-
-            PluginContainer? container = _currentContainer;
-
-            if (container == null)
-                throw new InvalidOperationException("No plugin loaded");
-
-            using var _ = container.Tracker.EnterRequest();
-            try
+            foreach (var listener in _mapListeners)
             {
-                container.Instance.ReactorAct(c, reactor).ConfigureAwait(false).GetAwaiter().GetResult();
-            }
-            catch (Exception e)
-            {
-                if (e is BusinessException)
+                try
                 {
-                    c.OnlinedCharacter.Pink(e.Message);
+                    listener.OnMapObjectEnterField(map, mapObject);
                 }
-                Log.Logger.Error(e, "Reactor script error in: Map={Map}.Reactor={Reactor}", reactor.getMap().Id, reactor.getId());
+                catch (Exception ex)
+                {
+                    Log.Logger.Error(ex, "MapListener.OnMapObjectEnterField error");
+                }
             }
         }
 
-        internal int RegisterEvents(WorldChannel channel)
+        public void OnMapObjectLeaveField(IMap map, IMapObject mapObject)
         {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(PluginManager));
-
-            PluginContainer? container = _currentContainer;
-
-            if (container == null)
-                throw new InvalidOperationException("No plugin loaded");
-
-            using var _ = container.Tracker.EnterRequest();
-            try
+            foreach (var listener in _mapListeners)
             {
-                return container.Instance.RegisterEvents(channel);
-            }
-            catch (Exception e)
-            {
-                Log.Logger.Error(e.ToString());
-            }
-            return 0;
-        }
-        #endregion
-
-
-        /// <summary>
-        /// 从源目录复制 DLL 到卷影副本，并加载
-        /// </summary>
-        private PluginContainer LoadPluginFromSourceAsync(string pluginDllName)
-        {
-            string sourcePath = Path.Combine(_sourcePluginDir, pluginDllName);
-            if (!File.Exists(sourcePath))
-                throw new FileNotFoundException($"Plugin not found: {sourcePath}");
-
-            // 创建唯一的卷影副本目录
-            string shadowDir = Path.Combine(_shadowCopyBaseDir, Guid.NewGuid().ToString());
-            Directory.CreateDirectory(shadowDir);
-
-            string shadowDllPath = Path.Combine(shadowDir, pluginDllName);
-            File.Copy(sourcePath, shadowDllPath, overwrite: true);
-
-            // 创建自定义加载上下文
-            var loadContext = new PluginLoadContext(shadowDllPath);
-
-            // 加载插件程序集
-            Assembly pluginAssembly;
-            try
-            {
-                pluginAssembly = loadContext.LoadFromAssemblyPath(shadowDllPath);
-            }
-            catch (Exception ex)
-            {
-                // 加载失败，清理目录
-                Directory.Delete(shadowDir, recursive: true);
-                throw new InvalidOperationException($"Failed to load plugin from {shadowDllPath}", ex);
-            }
-
-            // 查找实现了 IGamePlugin 的类型
-            var pluginType = pluginAssembly.GetTypes()
-                .FirstOrDefault(t => typeof(IScriptService).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract);
-
-            if (pluginType == null)
-            {
-                loadContext.Unload();
-                Directory.Delete(shadowDir, recursive: true);
-                throw new InvalidOperationException($"No type implementing {nameof(IScriptService)} found in {pluginDllName}");
-            }
-
-            // 创建插件实例（假设有无参构造函数）
-            var pluginInstance = (IScriptService)Activator.CreateInstance(pluginType);
-
-            // 可选：如果插件需要宿主服务，在这里注入（例如通过构造函数或属性）
-            // 例如：InjectServices(pluginInstance);
-
-            return new PluginContainer(pluginInstance, loadContext, shadowDir);
-        }
-
-        /// <summary>
-        /// 释放管理器：卸载当前插件
-        /// </summary>
-        public async ValueTask DisposeAsync()
-        {
-            if (_disposed)
-                return;
-
-            _disposed = true;
-
-            var container = _currentContainer;
-            _currentContainer = null;
-            if (container != null)
-            {
-                await container.DisposeAsync().ConfigureAwait(false);
+                try
+                {
+                    listener.OnMapObjectLeaveField(map, mapObject);
+                }
+                catch (Exception ex)
+                {
+                    Log.Logger.Error(ex, "MapListener.OnMapObjectLeaveField error");
+                }
             }
         }
     }

--- a/src/Application.Core/Gameplay/Plugins/ScriptManager.cs
+++ b/src/Application.Core/Gameplay/Plugins/ScriptManager.cs
@@ -32,7 +32,7 @@ namespace Application.Core.Gameplay.Plugins
         }
 
         #region Services
-        private PluginContainer<IScriptService> EnsureNotDisposedAndGetContainer()
+        private PluginContainer<IScriptService> GetActiveContainer()
         {
             if (_disposed)
                 throw new ObjectDisposedException(nameof(ScriptManager));
@@ -41,7 +41,7 @@ namespace Application.Core.Gameplay.Plugins
             if (containers.Count == 0)
                 throw new InvalidOperationException("No script plugin loaded.");
             if (containers.Count > 1)
-                Log.Logger.Warning("Multiple script plugins loaded, using the first one.");
+                throw new InvalidOperationException("Multiple script plugins loaded.");
 
             return containers[0];
         }
@@ -51,13 +51,13 @@ namespace Application.Core.Gameplay.Plugins
             if (container.PluginServices.Count == 0)
                 throw new InvalidOperationException("No script service loaded.");
             if (container.PluginServices.Count > 1)
-                Log.Logger.Warning("Multiple script service loaded, using the first one.");
+                throw new InvalidOperationException("Multiple script service loaded.");
 
             return container.PluginServices[0];
         }
         public async Task<bool> StartNpcConversation(IChannelClient c, int npcId, NPC? npcObject, string? scriptName)
         {
-            var container = EnsureNotDisposedAndGetContainer();
+            var container = GetActiveContainer();
             using var _ = container.Tracker.EnterRequest();
             try
             {
@@ -76,7 +76,7 @@ namespace Application.Core.Gameplay.Plugins
 
         public async Task<bool> ProcessQuestConversation(IChannelClient c, server.quest.Quest questObj, int npcId, bool isStart)
         {
-            var container = EnsureNotDisposedAndGetContainer();
+            var container = GetActiveContainer();
             using var _ = container.Tracker.EnterRequest();
             try
             {
@@ -102,7 +102,7 @@ namespace Application.Core.Gameplay.Plugins
 
         public async Task MoreNpcConversation(IChannelClient c, sbyte mode, sbyte type, int selection, string? inputText = null)
         {
-            var container = EnsureNotDisposedAndGetContainer();
+            var container = GetActiveContainer();
             using var _ = container.Tracker.EnterRequest();
             try
             {
@@ -120,7 +120,7 @@ namespace Application.Core.Gameplay.Plugins
 
         public bool EnterPortal(IChannelClient c, Portal p)
         {
-            var container = EnsureNotDisposedAndGetContainer();
+            var container = GetActiveContainer();
             using var _ = container.Tracker.EnterRequest();
             try
             {
@@ -139,7 +139,7 @@ namespace Application.Core.Gameplay.Plugins
 
         public async Task ItemScript(IChannelClient c, int npcId, string scriptName)
         {
-            var container = EnsureNotDisposedAndGetContainer();
+            var container = GetActiveContainer();
             using var _ = container.Tracker.EnterRequest();
             try
             {
@@ -157,7 +157,7 @@ namespace Application.Core.Gameplay.Plugins
 
         public void MapEnterScript(IChannelClient c, IMap map)
         {
-            var container = EnsureNotDisposedAndGetContainer();
+            var container = GetActiveContainer();
             using var _ = container.Tracker.EnterRequest();
             try
             {
@@ -175,7 +175,7 @@ namespace Application.Core.Gameplay.Plugins
 
         public void MapFirstEnterScript(IChannelClient c, IMap map)
         {
-            var container = EnsureNotDisposedAndGetContainer();
+            var container = GetActiveContainer();
             using var _ = container.Tracker.EnterRequest();
             try
             {
@@ -193,7 +193,7 @@ namespace Application.Core.Gameplay.Plugins
 
         internal void ReactorHit(IChannelClient c, Reactor reactor)
         {
-            var container = EnsureNotDisposedAndGetContainer();
+            var container = GetActiveContainer();
             using var _ = container.Tracker.EnterRequest();
             try
             {
@@ -212,7 +212,7 @@ namespace Application.Core.Gameplay.Plugins
 
         internal void ReactorAct(IChannelClient c, Reactor reactor)
         {
-            var container = EnsureNotDisposedAndGetContainer();
+            var container = GetActiveContainer();
             using var _ = container.Tracker.EnterRequest();
             try
             {
@@ -231,7 +231,7 @@ namespace Application.Core.Gameplay.Plugins
 
         internal int RegisterEvents(WorldChannel channel)
         {
-            var container = EnsureNotDisposedAndGetContainer();
+            var container = GetActiveContainer();
             using var _ = container.Tracker.EnterRequest();
             try
             {

--- a/src/Application.Core/Gameplay/Plugins/ScriptManager.cs
+++ b/src/Application.Core/Gameplay/Plugins/ScriptManager.cs
@@ -1,0 +1,248 @@
+using Application.Core.Channel;
+using Application.Core.Game.Life;
+using Application.Core.Game.Maps;
+using Application.Core.Plugins;
+using server.maps;
+
+namespace Application.Core.Gameplay.Plugins
+{
+    /// <summary>
+    /// 脚本插件
+    /// </summary>
+    public sealed class ScriptManager : AbstractPluginManager<IScriptService>
+    {
+        public ScriptManager(WorldChannelServer server) : base(server)
+        {
+        }
+
+        public override async Task<bool> LoadPlugin(string pluginDllName)
+        {
+            if (await LoadPluginInternal(pluginDllName, false))
+            {
+                foreach (var channel in _server.Servers.Values.OfType<WorldChannel>().ToArray())
+                {
+                    Log.Logger.Information("[{ServerName}] 初始化事件...", channel.InstanceName);
+                    RegisterEvents(channel);
+                    Log.Logger.Information("[{ServerName}] 初始化事件（{EventCount}项）...完成", channel.InstanceName, channel.EventScriptManager.EventCount);
+                }
+
+                return true;
+            }
+            return false;
+        }
+
+        #region Services
+        private PluginContainer<IScriptService> EnsureNotDisposedAndGetContainer()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(ScriptManager));
+
+            var containers = _pluginContainers.Values.ToList();
+            if (containers.Count == 0)
+                throw new InvalidOperationException("No script plugin loaded.");
+            if (containers.Count > 1)
+                Log.Logger.Warning("Multiple script plugins loaded, using the first one.");
+
+            return containers[0];
+        }
+
+        IScriptService GetScriptService(PluginContainer<IScriptService> container)
+        {
+            if (container.PluginServices.Count == 0)
+                throw new InvalidOperationException("No script service loaded.");
+            if (container.PluginServices.Count > 1)
+                Log.Logger.Warning("Multiple script service loaded, using the first one.");
+
+            return container.PluginServices[0];
+        }
+        public async Task<bool> StartNpcConversation(IChannelClient c, int npcId, NPC? npcObject, string? scriptName)
+        {
+            var container = EnsureNotDisposedAndGetContainer();
+            using var _ = container.Tracker.EnterRequest();
+            try
+            {
+                return await GetScriptService(container).Start(c, npcId, npcObject, scriptName);
+            }
+            catch (Exception e)
+            {
+                if (e is BusinessException)
+                {
+                    c.OnlinedCharacter.Pink(e.Message);
+                }
+                Log.Logger.Error(e, "Npc script error in: {ScriptName}", scriptName);
+            }
+            return false;
+        }
+
+        public async Task<bool> ProcessQuestConversation(IChannelClient c, server.quest.Quest questObj, int npcId, bool isStart)
+        {
+            var container = EnsureNotDisposedAndGetContainer();
+            using var _ = container.Tracker.EnterRequest();
+            try
+            {
+                if (isStart)
+                {
+                    return await GetScriptService(container).StartQuest(c, questObj, npcId);
+                }
+                else
+                {
+                    return await GetScriptService(container).CompleteQuest(c, questObj, npcId);
+                }
+            }
+            catch (Exception e)
+            {
+                if (e is BusinessException)
+                {
+                    c.OnlinedCharacter.Pink(e.Message);
+                }
+                Log.Logger.Error(e, "Quest script error in: QuestId={QuestId}", questObj.getId());
+            }
+            return false;
+        }
+
+        public async Task MoreNpcConversation(IChannelClient c, sbyte mode, sbyte type, int selection, string? inputText = null)
+        {
+            var container = EnsureNotDisposedAndGetContainer();
+            using var _ = container.Tracker.EnterRequest();
+            try
+            {
+                await GetScriptService(container).Action(c, mode, type, selection, inputText);
+            }
+            catch (Exception e)
+            {
+                if (e is BusinessException)
+                {
+                    c.OnlinedCharacter.Pink(e.Message);
+                }
+                Log.Logger.Error(e, "Npc script error more talk");
+            }
+        }
+
+        public bool EnterPortal(IChannelClient c, Portal p)
+        {
+            var container = EnsureNotDisposedAndGetContainer();
+            using var _ = container.Tracker.EnterRequest();
+            try
+            {
+                return GetScriptService(container).Enter(c, p);
+            }
+            catch (Exception e)
+            {
+                if (e is BusinessException)
+                {
+                    c.OnlinedCharacter.Pink(e.Message);
+                }
+                Log.Logger.Error(e, "Portal script error in: {ScriptName}", p.getScriptName());
+            }
+            return false;
+        }
+
+        public async Task ItemScript(IChannelClient c, int npcId, string scriptName)
+        {
+            var container = EnsureNotDisposedAndGetContainer();
+            using var _ = container.Tracker.EnterRequest();
+            try
+            {
+                await GetScriptService(container).ItemScript(c, npcId, scriptName);
+            }
+            catch (Exception e)
+            {
+                if (e is BusinessException)
+                {
+                    c.OnlinedCharacter.Pink(e.Message);
+                }
+                Log.Logger.Error(e, "Item script error in: {ScriptName}", scriptName);
+            }
+        }
+
+        public void MapEnterScript(IChannelClient c, IMap map)
+        {
+            var container = EnsureNotDisposedAndGetContainer();
+            using var _ = container.Tracker.EnterRequest();
+            try
+            {
+                GetScriptService(container).MapEnter(c, map);
+            }
+            catch (Exception e)
+            {
+                if (e is BusinessException)
+                {
+                    c.OnlinedCharacter.Pink(e.Message);
+                }
+                Log.Logger.Error(e, "Map script error in: {Map}(Enter)", map.Id);
+            }
+        }
+
+        public void MapFirstEnterScript(IChannelClient c, IMap map)
+        {
+            var container = EnsureNotDisposedAndGetContainer();
+            using var _ = container.Tracker.EnterRequest();
+            try
+            {
+                GetScriptService(container).MapFirstEnter(c, map);
+            }
+            catch (Exception e)
+            {
+                if (e is BusinessException)
+                {
+                    c.OnlinedCharacter.Pink(e.Message);
+                }
+                Log.Logger.Error(e, "Map script error in: {Map}(FirstEnter)", map.Id);
+            }
+        }
+
+        internal void ReactorHit(IChannelClient c, Reactor reactor)
+        {
+            var container = EnsureNotDisposedAndGetContainer();
+            using var _ = container.Tracker.EnterRequest();
+            try
+            {
+                // TODO: 日后将所有handler改成async/await后再解决
+                GetScriptService(container).ReactorHit(c, reactor).ConfigureAwait(false).GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                if (e is BusinessException)
+                {
+                    c.OnlinedCharacter.Pink(e.Message);
+                }
+                Log.Logger.Error(e, "Reactor script error in: Map={Map}.Reactor={Reactor}", reactor.getMap().Id, reactor.getId());
+            }
+        }
+
+        internal void ReactorAct(IChannelClient c, Reactor reactor)
+        {
+            var container = EnsureNotDisposedAndGetContainer();
+            using var _ = container.Tracker.EnterRequest();
+            try
+            {
+                // TODO: 日后将所有handler改成async/await后再解决
+                GetScriptService(container).ReactorAct(c, reactor).ConfigureAwait(false).GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                if (e is BusinessException)
+                {
+                    c.OnlinedCharacter.Pink(e.Message);
+                }
+                Log.Logger.Error(e, "Reactor script error in: Map={Map}.Reactor={Reactor}", reactor.getMap().Id, reactor.getId());
+            }
+        }
+
+        internal int RegisterEvents(WorldChannel channel)
+        {
+            var container = EnsureNotDisposedAndGetContainer();
+            using var _ = container.Tracker.EnterRequest();
+            try
+            {
+                return GetScriptService(container).RegisterEvents(channel);
+            }
+            catch (Exception e)
+            {
+                Log.Logger.Error(e.ToString());
+                return 0;
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Application.Core/Scripting/Events/AbstractInstancedEventManager.cs
+++ b/src/Application.Core/Scripting/Events/AbstractInstancedEventManager.cs
@@ -86,6 +86,19 @@ namespace Application.Core.Scripting.Events
             MinCount = YamlConfig.config.server.USE_ENABLE_SOLO_EXPEDITIONS ? 1 : MinCount;
         }
 
+        public override void Inherit(EventManager em)
+        {
+            base.Inherit(em);
+
+            if (em is AbstractInstancedEventManager iEm)
+            {
+                instances = new ConcurrentDictionary<string, AbstractEventInstanceManager>(iEm.instances);
+                openedLobbys = new Dictionary<int, bool>(iEm.openedLobbys);
+                readyInstances = new Queue<AbstractEventInstanceManager>(iEm.readyInstances);
+                onLoadInstances = iEm.onLoadInstances;
+                readyId = iEm.readyId;
+            }
+        }
         #region Instances
         protected virtual AbstractEventInstanceManager CreateNewInstance(string instanceName)
         {

--- a/src/Application.Core/Scripting/Events/EventManager.cs
+++ b/src/Application.Core/Scripting/Events/EventManager.cs
@@ -15,15 +15,13 @@ public class EventManager : IDisposable, ITickableTree
     public string Name => _name;
 
 
-    private Dictionary<string, string> props = new Dictionary<string, string>();
-
     /// <summary>
     /// 事件名
     /// </summary>
     protected string _name;
 
     public TickableStatus Status { get; private set; }
-    public List<ITickable> SubTickables { get; }
+    public List<ITickable> SubTickables { get; private set; }
 
     public EventManager(WorldChannel cserv, string name)
     {
@@ -37,7 +35,17 @@ public class EventManager : IDisposable, ITickableTree
     {
 
     }
-
+    /// <summary>
+    /// 会被dispose的属性都继承
+    /// </summary>
+    /// <param name="em"></param>
+    public virtual void Inherit(EventManager em)
+    {
+        _name = em._name;
+        disposed = em.disposed;
+        Status = em.Status;
+        SubTickables = new List<ITickable>(em.SubTickables);
+    }
 
     bool disposed = false;
     protected bool isDisposed()
@@ -52,7 +60,6 @@ public class EventManager : IDisposable, ITickableTree
 
         disposed = true;
         Status = TickableStatus.Remove;
-        props.Clear();
     }
 
     public long getLobbyDelay()
@@ -71,30 +78,6 @@ public class EventManager : IDisposable, ITickableTree
         return map;
     }
 
-    public void setProperty(string key, string value)
-    {
-        props[key] = value;
-    }
-
-    public void setIntProperty(string key, int value)
-    {
-        setProperty(key, value);
-    }
-
-    public void setProperty(string key, long value)
-    {
-        setProperty(key, value.ToString());
-    }
-
-    public string? getProperty(string key)
-    {
-        return props.GetValueOrDefault(key);
-    }
-
-    public int getIntProperty(string key)
-    {
-        return int.Parse(props.GetValueOrDefault(key) ?? "0");
-    }
 
 
     public string getName()
@@ -124,11 +107,6 @@ public class EventManager : IDisposable, ITickableTree
         {
             log.Error(ex.ToString());
         }
-    }
-
-    public int getTransportationTime(double travelTime)
-    {
-        return cserv.getTransportationTime(travelTime);
     }
 
     public virtual void OnTick(long now)

--- a/src/Application.Core/Scripting/Events/EventScriptManager.cs
+++ b/src/Application.Core/Scripting/Events/EventScriptManager.cs
@@ -36,6 +36,7 @@ public class EventScriptManager : ITickableTree, IDisposable
 {
     private ConcurrentDictionary<string, EventManager> events = new();
     public bool IsActive => events.Count > 0;
+    public int EventCount => events.Count;
     public WorldChannel ChannelServer { get; }
 
     public EventScriptManager(WorldChannel channel)
@@ -43,10 +44,19 @@ public class EventScriptManager : ITickableTree, IDisposable
         ChannelServer = channel;
     }
 
-
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="emList"></param>
+    /// <returns></returns>
+    /// <exception cref="BusinessFatalException"></exception>
     public int ReloadEventScript(List<EventManager> emList)
     {
-        DisposeEvents();
+        var duplicatedItem = emList.GroupBy(x => x.getName()).FirstOrDefault(x => x.Count() > 1);
+        if (duplicatedItem != null)
+        {
+            throw new BusinessFatalException($"事件名重复，名称：{duplicatedItem.Key}");
+        }
 
         foreach (var em in emList)
         {
@@ -54,11 +64,11 @@ public class EventScriptManager : ITickableTree, IDisposable
             {
                 em.Initialize();
 
-                if (!events.TryAdd(em.getName(), em))
+                if (events.TryGetValue(em.getName(), out var old))
                 {
-                    throw new BusinessFatalException($"事件名重复，名称：{em.getName()}");
+                    em.Inherit(old);
                 }
-
+                events[em.getName()] = em;
             }
             catch (Exception ex)
             {
@@ -88,15 +98,6 @@ public class EventScriptManager : ITickableTree, IDisposable
         return IsActive;
     }
 
-    public void DisposeEvents()
-    {
-        var cleanEvents = events.Values.ToList();
-        foreach (var old in cleanEvents)
-        {
-            old.Dispose();
-        }
-        events.Clear();
-    }
 
     public void Dispose()
     {
@@ -105,7 +106,12 @@ public class EventScriptManager : ITickableTree, IDisposable
             return;
         }
 
-        DisposeEvents();
+        var cleanEvents = events.Values.ToList();
+        events.Clear();
+        foreach (var old in cleanEvents)
+        {
+            old.Dispose();
+        }
     }
 
     public TickableStatus Status { get; protected set; }

--- a/src/Application.Core/Scripting/Events/MonsterCarnivalEventManager.cs
+++ b/src/Application.Core/Scripting/Events/MonsterCarnivalEventManager.cs
@@ -106,7 +106,7 @@ namespace Application.Core.Scripting.Events
 
             eim.RequestTeam = new TeamRegistry(members);
             // send challenge
-            if (await ChannelServer.NodeService.PluginManager.StartNpcConversation(
+            if (await ChannelServer.NodeService.ScriptManager.StartNpcConversation(
                 eim.getLeader()!.Client,
                 2042001,
                 null,

--- a/src/Application.Core/Scripting/item/ItemScriptManager.cs
+++ b/src/Application.Core/Scripting/item/ItemScriptManager.cs
@@ -38,6 +38,6 @@ public class ItemScriptManager
 
     public void runItemScript(IChannelClient c, ScriptItemTemplate scriptItem)
     {
-        c.CurrentServer.NodeService.PluginManager.ItemScript(c, scriptItem.Npc, scriptItem.Script).ConfigureAwait(false).GetAwaiter().GetResult();
+        c.CurrentServer.NodeService.ScriptManager.ItemScript(c, scriptItem.Npc, scriptItem.Script).ConfigureAwait(false).GetAwaiter().GetResult();
     }
 }

--- a/src/Application.Core/Scripting/reactor/ReactorScriptManager.cs
+++ b/src/Application.Core/Scripting/reactor/ReactorScriptManager.cs
@@ -44,12 +44,12 @@ public class ReactorScriptManager : AbstractScriptManager
 
     public void onHit(IChannelClient c, Reactor reactor)
     {
-        c.CurrentServer.NodeService.PluginManager.ReactorHit(c, reactor);
+        c.CurrentServer.NodeService.ScriptManager.ReactorHit(c, reactor);
     }
 
     public void act(IChannelClient c, Reactor reactor)
     {
-        c.CurrentServer.NodeService.PluginManager.ReactorAct(c, reactor);
+        c.CurrentServer.NodeService.ScriptManager.ReactorAct(c, reactor);
     }
 
     public List<DropEntry> getDrops(int reactorId)

--- a/src/Application.Core/server/maps/GenericPortal.cs
+++ b/src/Application.Core/server/maps/GenericPortal.cs
@@ -127,7 +127,7 @@ public class GenericPortal : Portal
         {
             try
             {
-                changed = c.CurrentServer.NodeService.PluginManager.EnterPortal(c, this);
+                changed = c.CurrentServer.NodeService.ScriptManager.EnterPortal(c, this);
             }
             catch (NullReferenceException npe)
             {

--- a/src/Application.Plugin.Script/Npc/NpcScript.cs
+++ b/src/Application.Plugin.Script/Npc/NpcScript.cs
@@ -1162,7 +1162,7 @@ namespace Application.Plugin.Script.Npc
                     return;
                 }
 
-                var pqOption = await AskMenu($"#e#b<组队任务：高级之路 - {levels[area]}>\r\n#k#n" + em.getProperty("party") + "\r\n\r\n#p1052014# 的操作方式与普通的不同。它们不使用金币或扭蛋券，而是使用 #r橡皮擦#k，可以通过完成高级之路上的任务获得。要前往那里，你必须找到队友并参加一个组队任务。当组队并准备好后，让你的 #b队长#k 与我交谈。", [
+                var pqOption = await AskMenu($"#e#b<组队任务：高级之路 - {levels[area]}>\r\n#k#n" + em.GetRequirementDescription(c) + "\r\n\r\n#p1052014# 的操作方式与普通的不同。它们不使用金币或扭蛋券，而是使用 #r橡皮擦#k，可以通过完成高级之路上的任务获得。要前往那里，你必须找到队友并参加一个组队任务。当组队并准备好后，让你的 #b队长#k 与我交谈。", [
                     "我想参加组队任务。",
                     "我想了解更多详情。"
                 ]);
@@ -2417,7 +2417,6 @@ namespace Application.Plugin.Script.Npc
                 if (choice == 0)
                 {
                     var pepe = GetEventManager<PartyQuestEventManager>("KingPepeAndYetis");
-                    pepe.setProperty("player", getPlayer().getName());
                     var r = pepe.StartInstance(getPlayer());
                     await SayOK(pepe.HandleCreateInstanceResult(r, c));
                 }
@@ -2440,7 +2439,6 @@ namespace Application.Plugin.Script.Npc
                 if (sel == 1)
                 {
                     var pepe = GetEventManager<PartyQuestEventManager>("KingPepeAndYetis");
-                    pepe.setProperty("player", getPlayer().getName());
                     var r = pepe.StartInstance(getPlayer());
                     await SayOK(pepe.HandleCreateInstanceResult(r, c));
                 }
@@ -3417,7 +3415,7 @@ namespace Application.Plugin.Script.Npc
                 return;
             }
 
-            var option = await AskMenu($"#e#b<组队任务：元素塔纳托斯>\r\n#k#n{em.getProperty("party")}\r\n\r\n你正在寻找元素塔纳托斯，对吗？如果你和另一个法师组队，而且他的元素属性与你相反，你们就能够克服它们。作为队长，当你准备好出发时，和我交谈。", [
+            var option = await AskMenu($"#e#b<组队任务：元素塔纳托斯>\r\n#k#n{em.GetRequirementDescription(c)}\r\n\r\n你正在寻找元素塔纳托斯，对吗？如果你和另一个法师组队，而且他的元素属性与你相反，你们就能够克服它们。作为队长，当你准备好出发时，和我交谈。", [
                 "我想参加组队任务。",
                 "我想了解更多细节。"
             ]);
@@ -3975,7 +3973,7 @@ namespace Application.Plugin.Script.Npc
                     return;
                 }
 
-                var option = await AskMenu($"#e#b<组队任务：拯救 Delli>\r\n#k#n{em.getProperty("party")}\r\n\r\n啊，#r#p1095000##k 让你来的？她担心我吗？... 很抱歉听到这个消息，但我现在真的不能回去，一些怪物受到黑魔法师的影响，我需要解救它们！... 你似乎也不会接受这个事实，对吗？你愿意和队友一起帮助我吗？如果愿意，请让你的 #b队长#k 和我交谈。", [
+                var option = await AskMenu($"#e#b<组队任务：拯救 Delli>\r\n#k#n{em.GetRequirementDescription(c)}\r\n\r\n啊，#r#p1095000##k 让你来的？她担心我吗？... 很抱歉听到这个消息，但我现在真的不能回去，一些怪物受到黑魔法师的影响，我需要解救它们！... 你似乎也不会接受这个事实，对吗？你愿意和队友一起帮助我吗？如果愿意，请让你的 #b队长#k 和我交谈。", [
                     "我想参加组队任务。",
                     "我想了解更多细节。"
                 ]);
@@ -4636,7 +4634,7 @@ namespace Application.Plugin.Script.Npc
                 }
 
                 var option = await AskMenu(
-                    "#e#b<组队任务：首领突袭>\r\n#k#n" + em.getProperty("party") +
+                    "#e#b<组队任务：首领突袭>\r\n#k#n" + em.GetRequirementDescription(c) +
                     "\r\n\r\n你想要和队友合作完成远征任务，还是勇敢到足以独自完成？让你的#b队伍领袖#k与我交谈或者自己创建一个队伍。",
                     [
                         "我想参加组队任务。",

--- a/src/Application.Plugin.Script/ScriptService.cs
+++ b/src/Application.Plugin.Script/ScriptService.cs
@@ -16,7 +16,6 @@ using Serilog;
 using server.maps;
 using System.Reflection;
 using tools;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Application.Plugin.Script
 {

--- a/src/Application.Utility/Extensions/ObjectExtensions.cs
+++ b/src/Application.Utility/Extensions/ObjectExtensions.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Reflection;
+using System.Security.Cryptography;
 
 namespace Application.Utility.Extensions
 {
@@ -120,6 +121,34 @@ namespace Application.Utility.Extensions
                 }
             }
             return (T)result;
+        }
+
+        /// <summary>
+        /// 计算文件的哈希值
+        /// </summary>
+        /// <param name="filePath">文件路径</param>
+        /// <param name="algorithmName">算法名称: MD5, SHA1, SHA256, SHA384, SHA512</param>
+        /// <returns>十六进制字符串（小写）</returns>
+        public static string ComputeFileHash(this string filePath, string algorithmName = "SHA256")
+        {
+            using (var fileStream = File.OpenRead(filePath))
+            {
+                HashAlgorithm algorithm = algorithmName.ToUpperInvariant() switch
+                {
+                    "MD5" => MD5.Create(),
+                    "SHA1" => SHA1.Create(),
+                    "SHA256" => SHA256.Create(),
+                    "SHA384" => SHA384.Create(),
+                    "SHA512" => SHA512.Create(),
+                    _ => throw new NotSupportedException($"算法 {algorithmName} 不支持")
+                };
+
+                using (algorithm)
+                {
+                    byte[] hashBytes = algorithm.ComputeHash(fileStream);
+                    return BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- 插件拆分，分为普通插件和脚本插件：普通插件支持注册多个插件，脚本插件仅允许单个插件生效
- 事件脚本注册由脚本插件生命周期管理
- 调整`EventManager`，移除`EventManager`中没用的字段
- 重载事件脚本时，将旧事件的属性传给新事件，避免丢失