### PR TITLE
优化：飞镖等射击类道具的使用 

### DIFF
--- a/src/Application.Core/Channel/Net/Handlers/AbstractDealDamageHandler.cs
+++ b/src/Application.Core/Channel/Net/Handlers/AbstractDealDamageHandler.cs
@@ -50,7 +50,7 @@ public abstract class AbstractDealDamageHandler : ChannelHandlerBase
         this.autoBanDataManager = autoBanDataManager;
     }
 
-    protected async Task applyAttack(AttackInfo attack, Player player, int attackCount)
+    protected async Task applyAttack(AttackInfo attack, Player player)
     {
         var map = player.getMap();
         if (await map.isOwnershipRestricted(player))
@@ -439,13 +439,13 @@ public abstract class AbstractDealDamageHandler : ChannelHandlerBase
                             await player.ChangeHP((int)((totDamage * skill.getEffect(player.getSkillLevel(skill)).getX()) / 100.0));
                         });
                     }
-                    else if (player.JobModel == Job.NIGHTLORD || player.JobModel == Job.SHADOWER || player.JobModel == Job.NIGHTWALKER3)
+                    else if (attack.ranged && (player.JobModel == Job.NIGHTLORD || player.JobModel == Job.SHADOWER || player.JobModel == Job.NIGHTWALKER3))
                     {
                         Skill type = SkillFactory.GetSkillTrust(player.getJob().getId() == 412 ? 4120005 : (player.getJob().getId() == 1411 ? 14110004 : 4220005));
                         if (player.getSkillLevel(type) > 0)
                         {
                             StatEffect venomEffect = type.getEffect(player.getSkillLevel(type));
-                            for (int i = 0; i < attackCount; i++)
+                            for (int i = 0; i < attack.numDamage; i++)
                             {
                                 if (venomEffect.makeChanceResult())
                                 {

--- a/src/Application.Core/Channel/Net/Handlers/CloseRangeDamageHandler.cs
+++ b/src/Application.Core/Channel/Net/Handlers/CloseRangeDamageHandler.cs
@@ -218,6 +218,6 @@ public class CloseRangeDamageHandler : AbstractDealDamageHandler
             await chr.cancelBuffStats(BuffStat.WIND_WALK);
         }
 
-        await applyAttack(attack, chr, attackCount);
+        await applyAttack(attack, chr);
     }
 }

--- a/src/Application.Core/Channel/Net/Handlers/MagicDamageHandler.cs
+++ b/src/Application.Core/Channel/Net/Handlers/MagicDamageHandler.cs
@@ -89,7 +89,7 @@ public class MagicDamageHandler : AbstractDealDamageHandler
                 chr.addCooldown(attack.skill, c.CurrentServer.Node.getCurrentTime(), 1000 * (effect_.getCooldown()));
             }
         }
-        await applyAttack(attack, chr, effect.getAttackCount());
+        await applyAttack(attack, chr);
         var eaterSkill = SkillFactory.getSkill((chr.getJob().getId() - (chr.getJob().getId() % 10)) * 10000);// MP Eater, works with right job
         int eaterLevel = chr.getSkillLevel(eaterSkill);
         if (eaterLevel > 0)

--- a/src/Application.Core/Channel/Net/Handlers/RangedAttackHandler.cs
+++ b/src/Application.Core/Channel/Net/Handlers/RangedAttackHandler.cs
@@ -23,8 +23,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using Application.Core.Channel.DataProviders;
 using Application.Core.Channel.ServerData;
+using Application.Core.Client.inventory;
 using Application.Core.Game.Skills;
 using Application.Core.Server;
+using Application.Templates.Item.Consume;
+using Application.Templates.Skill;
+using client.inventory;
 using client.inventory.manipulator;
 using Microsoft.Extensions.Logging;
 using tools;
@@ -67,13 +71,13 @@ public class RangedAttackHandler : AbstractDealDamageHandler
         {
             await chr.BroadcastMap(
                 PacketCreator.rangedAttack(chr, attack.skill, attack.skilllevel, attack.stance, attack.numAttackedAndDamage, 0, attack.targets, attack.speed, attack.direction, attack.display), chr.Id);
-            await applyAttack(attack, chr, 1);
+            await applyAttack(attack, chr);
         }
         else if (attack.skill == ThunderBreaker.SHARK_WAVE && chr.getSkillLevel(ThunderBreaker.SHARK_WAVE) > 0)
         {
             await chr.BroadcastMap(
                 PacketCreator.rangedAttack(chr, attack.skill, attack.skilllevel, attack.stance, attack.numAttackedAndDamage, 0, attack.targets, attack.speed, attack.direction, attack.display), chr.Id);
-            await applyAttack(attack, chr, 1);
+            await applyAttack(attack, chr);
 
             for (int i = 0; i < attack.numAttacked; i++)
             {
@@ -87,17 +91,17 @@ public class RangedAttackHandler : AbstractDealDamageHandler
             if (attack.skill == Aran.COMBO_SMASH && chr.getCombo() >= 30)
             {
                 await chr.setCombo(0);
-                await applyAttack(attack, chr, 1);
+                await applyAttack(attack, chr);
             }
             else if (attack.skill == Aran.COMBO_FENRIR && chr.getCombo() >= 100)
             {
                 await chr.setCombo(0);
-                await applyAttack(attack, chr, 2);
+                await applyAttack(attack, chr);
             }
             else if (attack.skill == Aran.COMBO_TEMPEST && chr.getCombo() >= 200)
             {
                 await chr.setCombo(0);
-                await applyAttack(attack, chr, 4);
+                await applyAttack(attack, chr);
             }
         }
         else
@@ -110,37 +114,44 @@ public class RangedAttackHandler : AbstractDealDamageHandler
             }
             short slot = -1;
             int projectile = 0;
-            short bulletCount = 1;
+            int bulletCount = 0;
             StatEffect? effect = null;
             if (attack.skill != 0)
             {
                 effect = await attack.getAttackEffect(chr, null);
-                if (effect == null)
+                if (effect == null  || effect.EffectTemplate is not SkillLevelData skillLevelData)
                 {
                     return;
                 }
 
-                bulletCount = effect.getBulletCount();
-                if (effect.getCooldown() > 0)
+                if (skillLevelData.BulletCount > 0)
                 {
-                    await c.SendPacket(PacketCreator.skillCooldown(attack.skill, effect.getCooldown()));
+                    bulletCount += skillLevelData.BulletCount;
                 }
 
-                if (attack.skill == Hermit.SHADOW_MESO)
-                {   // shadow meso
-                    bulletCount = 0;
+                if (skillLevelData.BulletConsume > 0)
+                {
+                    // 多重飞镖、快枪手
+                    // 暗器伤人属于BUFF，不会走这里
+                    bulletCount += skillLevelData.BulletConsume;
+                }
 
-                    int money = effect.getMoneyCon();
-                    if (money != 0)
+                if (skillLevelData.ItemConsume > 0)
+                {
+                    // 使用指定子弹
+                    projectile = skillLevelData.ItemConsume;
+                }
+
+                int money = skillLevelData.MoneyCon;
+                if (money != 0)
+                {
+                    int moneyMod = money / 2;
+                    money += Randomizer.nextInt(moneyMod);
+                    if (money > chr.getMeso())
                     {
-                        int moneyMod = money / 2;
-                        money += Randomizer.nextInt(moneyMod);
-                        if (money > chr.getMeso())
-                        {
-                            money = chr.getMeso();
-                        }
-                        await chr.GainMeso(-money);
+                        money = chr.getMeso();
                     }
+                    await chr.GainMeso(-money);
                 }
             }
             bool hasShadowPartner = chr.getBuffedValue(BuffStat.SHADOWPARTNER) != null;
@@ -148,75 +159,32 @@ public class RangedAttackHandler : AbstractDealDamageHandler
             {
                 bulletCount *= 2;
             }
-            var inv = chr.getInventory(InventoryType.USE);
-            for (short i = 1; i <= inv.getSlotLimit(); i++)
-            {
-                var item = inv.getItem(i);
-                if (item != null)
-                {
-                    int id = item.getItemId();
-                    slot = item.getPosition();
 
-                    bool bow = ItemConstants.isArrowForBow(id);
-                    bool cbow = ItemConstants.isArrowForCrossBow(id);
-                    if (item.getQuantity() >= bulletCount)
-                    { //Fixes the bug where you can't use your last arrow.
-                        if (type == WeaponType.CLAW && ItemConstants.isThrowingStar(id) && weapon.getItemId() != ItemId.MAGICAL_MITTEN)
-                        {
-                            if (((id == ItemId.HWABI_THROWING_STARS || id == ItemId.BALANCED_FURY) && chr.getLevel() < 70) || (id == ItemId.CRYSTAL_ILBI_THROWING_STARS && chr.getLevel() < 50))
-                            {
-                            }
-                            else
-                            {
-                                projectile = id;
-                                break;
-                            }
-                        }
-                        else if ((type == WeaponType.GUN && ItemConstants.isBullet(id)))
-                        {
-                            if (id == ItemId.BLAZE_CAPSULE || id == ItemId.GLAZE_CAPSULE)
-                            {
-                                if (chr.getLevel() >= 70)
-                                {
-                                    projectile = id;
-                                    break;
-                                }
-                            }
-                            else if (chr.getLevel() > (id % 10) * 20 + 9)
-                            {
-                                projectile = id;
-                                break;
-                            }
-                        }
-                        else if ((type == WeaponType.BOW && bow) || (type == WeaponType.CROSSBOW && cbow) || (weapon.getItemId() == ItemId.MAGICAL_MITTEN && (bow || cbow)))
-                        {
-                            projectile = id;
-                            break;
-                        }
-                    }
+            Item? usedBullet = null;
+            if (projectile  == 0)
+            {
+                usedBullet = chr.GetProperBulletItem(bulletCount);
+                if (usedBullet != null)
+                {
+                    slot = usedBullet.getPosition();
+                    projectile = usedBullet.getItemId();
                 }
             }
+
             bool soulArrow = chr.getBuffedValue(BuffStat.SOULARROW) != null;
             bool shadowClaw = chr.getBuffedValue(BuffStat.SHADOW_CLAW) != null;
-            if (projectile != 0)
+            if (projectile > 0 && !soulArrow && !shadowClaw)
             {
-                if (!soulArrow && !shadowClaw && attack.skill != DawnWarrior.SOUL_BLADE && attack.skill != ThunderBreaker.SHARK_WAVE && attack.skill != NightWalker.VAMPIRE)
+                if (usedBullet != null)
                 {
-                    short bulletConsume = bulletCount;
+                    // 理论上标飞没有无形箭，这里不作区分
+                    await InventoryManipulator.removeFromSlot(c, InventoryType.USE, slot, (short)bulletCount, false, true);
 
-                    if (effect != null && effect.getBulletConsume() != 0)
-                    {
-                        bulletConsume = (byte)(effect.getBulletConsume() * (hasShadowPartner ? 2 : 1));
-                    }
-
-                    if (slot < 0)
-                    {
-                        _logger.LogWarning("<ERROR> Projectile to use was unable to be found.");
-                    }
-                    else
-                    {
-                        await InventoryManipulator.removeFromSlot(c, InventoryType.USE, slot, bulletConsume, false, true);
-                    }
+                    await InventoryManipulator.RechargeBalanceFury(chr, usedBullet);
+                }
+                else
+                {
+                    await InventoryManipulator.removeById(c, InventoryType.USE, projectile, bulletCount, false, true);
                 }
             }
 
@@ -253,6 +221,7 @@ public class RangedAttackHandler : AbstractDealDamageHandler
                     || attack.skill == NightWalker.VAMPIRE
                     || attack.skill == WindArcher.STORM_BREAK)
                 {
+                    // 无形箭 / 不消耗飞镖的技能
                     visProjectile = 0;
                 }
 
@@ -271,11 +240,9 @@ public class RangedAttackHandler : AbstractDealDamageHandler
                 }
                 await chr.BroadcastMap(packet, chr.Id);
 
-                if (attack.skill != 0)
+                if (effect != null)
                 {
-                    var skill = SkillFactory.GetSkillTrust(attack.skill);
-                    StatEffect effect_ = skill.getEffect(chr.getSkillLevel(skill));
-                    var effectCooldown = effect_.getCooldown();
+                    var effectCooldown = effect.getCooldown();
                     if (effectCooldown > 0)
                     {
                         if (chr.skillIsCooling(attack.skill))
@@ -306,7 +273,7 @@ public class RangedAttackHandler : AbstractDealDamageHandler
                     await chr.cancelBuffStats(BuffStat.WIND_WALK);
                 }
 
-                await applyAttack(attack, chr, bulletCount);
+                await applyAttack(attack, chr);
             }
         }
     }

--- a/src/Application.Core/Channel/Net/Handlers/TouchMonsterDamageHandler.cs
+++ b/src/Application.Core/Channel/Net/Handlers/TouchMonsterDamageHandler.cs
@@ -37,7 +37,7 @@ public class TouchMonsterDamageHandler : AbstractDealDamageHandler
         var chr = c.OnlinedCharacter;
         if (chr.getEnergyBar() == 15000 || chr.getBuffedValue(BuffStat.BODY_PRESSURE) != null)
         {
-            await applyAttack(await parseDamage(p, chr, false, false), c.OnlinedCharacter, 1);
+            await applyAttack(await parseDamage(p, chr, false, false), c.OnlinedCharacter);
         }
     }
 }

--- a/src/Application.Core/Client/inventory/manipulator/InventoryManipulator.cs
+++ b/src/Application.Core/Client/inventory/manipulator/InventoryManipulator.cs
@@ -24,6 +24,7 @@
 using Application.Core.Channel.DataProviders;
 using Application.Core.Client.inventory;
 using Application.Resources.Messages;
+using System.Runtime.ConstrainedExecution;
 using tools;
 
 namespace client.inventory.manipulator;
@@ -317,6 +318,20 @@ public class InventoryManipulator
         if (removeRes != null && type != InventoryType.CANHOLD)
         {
             await chr.SyncClientInventory(removeRes, fromDrop);
+        }
+    }
+
+    /// <summary>
+    /// 自动补充平衡之怒
+    /// </summary>
+    /// <param name="chr"></param>
+    /// <param name="bulletItem"></param>
+    /// <returns></returns>
+    public static async Task RechargeBalanceFury(Player chr, Item bulletItem)
+    {
+        if (bulletItem.getItemId() == ItemId.BALANCED_FURY && bulletItem.getQuantity() <= 10)
+        {
+            await chr.RechargeBullet(bulletItem);
         }
     }
 

--- a/src/Application.Core/Game/Gameplay/AttackInfo.cs
+++ b/src/Application.Core/Game/Gameplay/AttackInfo.cs
@@ -6,7 +6,16 @@ namespace Application.Core.Game.Gameplay
 {
     public class AttackInfo
     {
-        public int numAttacked, numDamage, numAttackedAndDamage, skill, skilllevel, stance, direction, rangedirection, charge, display;
+        /// <summary>
+        /// 攻击到的怪物数量
+        /// </summary>
+        public int numAttacked { get; set; }
+        /// <summary>
+        /// 伤害段数
+        /// </summary>
+        public int numDamage { get; set; }
+        public int numAttackedAndDamage { get; set; }
+        public int skill, skilllevel, stance, direction, rangedirection, charge, display;
         public Dictionary<int, AttackTarget?> targets = new();
         public bool ranged, magic;
         public int speed = 4;

--- a/src/Application.Core/Game/Players/Character.cs
+++ b/src/Application.Core/Game/Players/Character.cs
@@ -2670,41 +2670,11 @@ public partial class Player
 
         if (JobModel.isA(Job.THIEF) || JobModel.isA(Job.BOWMAN) || JobModel.isA(Job.PIRATE) || JobModel.isA(Job.NIGHTWALKER1) || JobModel.isA(Job.WINDARCHER1))
         {
-            var weapon_item = getInventory(InventoryType.EQUIPPED).getItem(EquipSlot.Weapon);
-            if (weapon_item != null)
+            var activeBullet = GetProperBulletItem(1);
+            if (activeBullet != null)
             {
-                ItemInformationProvider ii = ItemInformationProvider.getInstance();
-                WeaponType weapon = ii.getWeaponType(weapon_item.getItemId());
-                bool bow = weapon == WeaponType.BOW;
-                bool crossbow = weapon == WeaponType.CROSSBOW;
-                bool claw = weapon == WeaponType.CLAW;
-                bool gun = weapon == WeaponType.GUN;
-                if (bow || crossbow || claw || gun)
-                {
-                    // Also calc stars into this.
-                    var inv = getInventory(InventoryType.USE);
-                    for (short i = 1; i <= inv.getSlotLimit(); i++)
-                    {
-                        var item = inv.getItem(i);
-                        if (item != null)
-                        {
-                            if ((claw && ItemConstants.isThrowingStar(item.getItemId()))
-                                || (gun && ItemConstants.isBullet(item.getItemId()))
-                                || (bow && ItemConstants.isArrowForBow(item.getItemId()))
-                                || (crossbow && ItemConstants.isArrowForCrossBow(item.getItemId())))
-                            {
-                                if (item.getQuantity() > 0)
-                                {
-                                    // Finally there!
-                                    localwatk += ((item.SourceTemplate as BulletItemTemplate)?.IncPAD ?? 0);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
+                localwatk += (activeBullet.SourceTemplate as BulletItemTemplate)!.IncPAD;
             }
-            // Add throwing stars to dmg.
         }
 
     }

--- a/src/Application.Core/Game/Players/Item.cs
+++ b/src/Application.Core/Game/Players/Item.cs
@@ -4,6 +4,7 @@ using Application.Core.Game.Items;
 using Application.Core.Game.Relation;
 using Application.Core.Server;
 using Application.Templates.Etc;
+using Application.Templates.Item.Consume;
 using Application.Utility.Performance;
 using client.inventory;
 using client.inventory.manipulator;
@@ -425,6 +426,42 @@ namespace Application.Core.Game.Players
 
             CashShopModel.BuyCashItem(cashType, cItem);
             await SendPacket(PacketCreator.showCash(this));
+        }
+
+        /// <summary>
+        /// 获取当前飞镖
+        /// CUserLocal::GetProperBulletPosition
+        /// </summary>
+        /// <returns></returns>
+        public Item? GetProperBulletItem(int useCount)
+        {
+            var weapon = getInventory(InventoryType.EQUIPPED).getItem(EquipSlot.Weapon);
+            if (weapon == null || !ItemId.IsShootingWeapon(weapon.getItemId()))
+            {
+                return null;
+            }
+
+            var inv = getInventory(InventoryType.USE);
+            for (short i = 1; i <= inv.getSlotLimit(); i++)
+            {
+                var item = inv.getItem(i);
+                if (item != null
+                    && item.SourceTemplate is BulletItemTemplate bulletItemTemplate
+                    && Level >= bulletItemTemplate.ReqLevel
+                    && item.getQuantity() >= useCount
+                    && ItemId.IsCorrectBulletItem(weapon.getItemId(), item.getItemId()))
+                {
+                    return item;
+                }
+            }
+            return null;
+        }
+
+        public async Task RechargeBullet(Item bulletItem)
+        {
+            var slotMax = ItemInformationProvider.getInstance().getSlotMax(Client, bulletItem.getItemId());
+            bulletItem.setQuantity(slotMax);
+            await SyncClientInventory(new InventoryUpdateQuantity(InventoryType.USE, bulletItem.getPosition(), slotMax));
         }
     }
 }

--- a/src/Application.Core/Game/Players/Item.cs
+++ b/src/Application.Core/Game/Players/Item.cs
@@ -449,7 +449,9 @@ namespace Application.Core.Game.Players
                     && item.SourceTemplate is BulletItemTemplate bulletItemTemplate
                     && Level >= bulletItemTemplate.ReqLevel
                     && item.getQuantity() >= useCount
-                    && ItemId.IsCorrectBulletItem(weapon.getItemId(), item.getItemId()))
+                    && ItemId.IsCorrectBulletItem(weapon.getItemId(), item.getItemId())
+                    && !ItemId.IsIcePelletItem(item.getItemId())
+                    && !ItemId.IsFirePelletItem(item.getItemId()))
                 {
                     return item;
                 }

--- a/src/Application.Core/Server/StatEffect.cs
+++ b/src/Application.Core/Server/StatEffect.cs
@@ -21,6 +21,8 @@
  */
 
 
+using Application.Core.Channel.DataProviders;
+using Application.Core.Client.inventory;
 using Application.Core.Game.Items;
 using Application.Core.Game.Life;
 using Application.Core.Game.Life.Monsters;
@@ -37,6 +39,7 @@ using Application.Templates.Skill;
 using Application.Templates.StatEffectProps;
 using client.inventory;
 using client.inventory.manipulator;
+using System.Runtime.ConstrainedExecution;
 using tools;
 
 namespace Application.Core.Server;
@@ -892,22 +895,7 @@ public class StatEffect
         if (isShadowClaw())
         {
             short projectileConsume = this.getBulletConsume();  // noticed by shavit
-
-            var use = applyto.getInventory(InventoryType.USE);
-
-            Item? projectile = null;
-            for (int i = 1; i <= use.getSlotLimit(); i++)
-            { // impose order...
-                var item = use.getItem((short)i);
-                if (item != null)
-                {
-                    if (ItemConstants.isThrowingStar(item.getItemId()) && item.getQuantity() >= projectileConsume)
-                    {
-                        projectile = item;
-                        break;
-                    }
-                }
-            }
+            var projectile = applyto.GetProperBulletItem(projectileConsume);
             if (projectile == null)
             {
                 return false;
@@ -915,6 +903,8 @@ public class StatEffect
             else
             {
                 await InventoryManipulator.removeFromSlot(applyto.Client, InventoryType.USE, projectile.getPosition(), projectileConsume, false, true);
+
+                await InventoryManipulator.RechargeBalanceFury(applyto, projectile);
             }
         }
         var summonMovementType = getSummonMovementType();

--- a/src/Application.Shared/Constants/Item/ItemId.cs
+++ b/src/Application.Shared/Constants/Item/ItemId.cs
@@ -93,30 +93,7 @@ public class ItemId
     }
 
     // Throwing star
-    public const int SUBI_THROWING_STARS = 2070000;
-    public const int HWABI_THROWING_STARS = 2070007;
     public const int BALANCED_FURY = 2070018;
-    public const int CRYSTAL_ILBI_THROWING_STARS = 2070016;
-    private static int THROWING_STAR_MIN = SUBI_THROWING_STARS;
-    private const int THROWING_STAR_MAX = 2070016;
-    public const int DEVIL_RAIN_THROWING_STAR = 2070014;
-
-    public static int[] allThrowingStarIds()
-    {
-        return Enumerable.Range(THROWING_STAR_MIN, THROWING_STAR_MAX - THROWING_STAR_MIN + 1).ToArray();
-    }
-
-    // Bullet
-    public const int BULLET = 2330000;
-    private const int BULLET_MIN = BULLET;
-    private const int BULLET_MAX = 2330005;
-    public const int BLAZE_CAPSULE = 2331000;
-    public const int GLAZE_CAPSULE = 2332000;
-
-    public static int[] allBulletIds()
-    {
-        return Enumerable.Range(BULLET_MIN, BULLET_MAX - BULLET_MIN + 1).ToArray();
-    }
 
     // Starter
     public const int BEGINNERS_GUIDE = 4161001;
@@ -491,4 +468,65 @@ public const int ENGAGEMENT_BOX_MOONSTONE = 2240000;
     public static int MITHRIL_PLATINE_PANTS = 1060091;
     public static int BLUE_CARZEN_BOOTS = 1072154;
     public static int MITHRIL_PLATINE = 1040103;
+
+    /// <summary>
+    /// int __cdecl get_weapon_type(int nItemID)
+    /// </summary>
+    /// <param name="itemId"></param>
+    /// <returns></returns>
+    public static int GetWeaponType(int nItemID)
+    {
+        int result; // eax
+
+        if (nItemID / 1000000 != 1)
+            return 0;
+        result = nItemID / 10000 % 100;
+        if (result < 30 || result > 33 && (result <= 36 || result > 49))
+            return 0;
+        return result;
+    }
+
+    /// <summary>
+    /// BOOL __cdecl is_shooting_weapon(int nItemID)
+    /// </summary>
+    /// <param name="nItemID"></param>
+    /// <returns></returns>
+    public static bool IsShootingWeapon(int nItemID)
+    {
+        int weapon_type; // eax
+
+        weapon_type = GetWeaponType(nItemID);
+        return weapon_type == 45 || weapon_type == 46 || weapon_type == 47 || weapon_type == 49;
+    }
+
+    /// <summary>
+    /// int __cdecl is_correct_bullet_item(int nWeaponItemID, int nItemID)
+    /// BOOL __cdecl sub_8C7F3C(int a1, int a2)
+    /// </summary>
+    /// <param name="nWeaponItemID"></param>
+    /// <param name="nItemID"></param>
+    /// <returns></returns>
+    public static bool IsCorrectBulletItem(int nWeaponItemID, int nItemID)
+    {
+        int weapon_type; // eax
+
+        weapon_type = GetWeaponType(nWeaponItemID);
+        if (weapon_type == 45 || nWeaponItemID == 1472063)
+            return nItemID / 1000 == 2060;
+        switch (weapon_type)
+        {
+            case 46:
+                return nItemID / 1000 == 2061;
+            case 47:
+                return nItemID / 10000 == 207;
+            case 49:
+                return IsPelletItem(nItemID);
+        }
+        return false;
+    }
+
+    public static bool IsPelletItem(int itemId)
+    {
+        return itemId / 10000 == 233;
+    }
 }

--- a/src/Application.Shared/Constants/Item/ItemId.cs
+++ b/src/Application.Shared/Constants/Item/ItemId.cs
@@ -529,4 +529,14 @@ public const int ENGAGEMENT_BOX_MOONSTONE = 2240000;
     {
         return itemId / 10000 == 233;
     }
+
+    public static bool IsIcePelletItem(int itemId)
+    {
+        return itemId / 1000 == 2332;
+    }
+
+    public static bool IsFirePelletItem(int itemId)
+    {
+        return itemId / 1000 == 2331;
+    }
 }

--- a/src/Application.Templates/Skill/SkillLevelData.cs
+++ b/src/Application.Templates/Skill/SkillLevelData.cs
@@ -67,6 +67,8 @@ namespace Application.Templates.Skill
         public int ItemCon { get; set; }
         [WZPath("~/itemConNo")]
         public int ItemConNo { get; set; }
+        [WZPath("~/itemConsume")]
+        public int ItemConsume { get; set; }
 
         [GenerateIgnoreProperty]
         public int HPR { get; set; }


### PR DESCRIPTION
- 修复平衡之怒自动补充
- 修复消耗飞镖时，筛选飞镖的等级判断使用wz的值
- 统一获取当前飞镖
- 修复武器用毒液的计算次数
- 修复技能寒冰/烈焰喷射的消耗